### PR TITLE
Added SKPhoto protocol (similar to IDMPhoto)

### DIFF
--- a/SKPhotoBrowser/SKCaptionView.swift
+++ b/SKPhotoBrowser/SKCaptionView.swift
@@ -14,7 +14,7 @@ public class SKCaptionView: UIView {
     var screenWidth :CGFloat { return screenBound.size.width }
     var screenHeight:CGFloat { return screenBound.size.height }
     
-    var photo:SKPhoto!
+    var photo:SKPhotoProtocol!
     var photoLabel:UILabel!
     var photoLabelPadding:CGFloat = 10
     
@@ -26,7 +26,7 @@ public class SKCaptionView: UIView {
         super.init(frame: frame)
     }
     
-    public convenience init(photo:SKPhoto) {
+    public convenience init(photo:SKPhotoProtocol) {
         let screenBound = UIScreen.mainScreen().bounds
         self.init(frame: CGRectMake(0, 0, screenBound.size.width, screenBound.size.height))
         self.photo = photo

--- a/SKPhotoBrowser/SKPhoto.swift
+++ b/SKPhotoBrowser/SKPhoto.swift
@@ -8,8 +8,16 @@
 
 import UIKit
 
+public protocol SKPhotoProtocol: NSObjectProtocol {
+    var underlyingImage:UIImage! { get }
+    var caption:String! { get }
+    
+    func loadUnderlyingImageAndNotify()
+    func checkCache()
+}
+
 // MARK: - SKPhoto
-public class SKPhoto:NSObject {
+public class SKPhoto:NSObject,SKPhotoProtocol {
     
     public var underlyingImage:UIImage!
     public var photoURL:String!

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -14,7 +14,7 @@ import UIKit
     optional func didDismissAtPageIndex(index:Int)
 }
 
-let SKPHOTO_LOADING_DID_END_NOTIFICATION = "photoLoadingDidEndNotification"
+public let SKPHOTO_LOADING_DID_END_NOTIFICATION = "photoLoadingDidEndNotification"
 
 // MARK: - SKPhotoBrowser
 public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
@@ -52,7 +52,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
     var currentPageIndex:Int = 0
     
     // photos
-    var photos:[SKPhoto] = [SKPhoto]()
+    var photos:[SKPhotoProtocol] = [SKPhotoProtocol]()
     var numberOfPhotos:Int{
         return photos.count
     }
@@ -92,21 +92,25 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
         setup()
     }
     
-    public convenience init(photos:[SKPhoto]) {
+    public convenience init(photos:[AnyObject]) {
         self.init(nibName: nil, bundle: nil)
-        for photo in photos{
-            photo.checkCache()
-            self.photos.append(photo)
+        for anyObject in photos{
+            if let photo = anyObject as? SKPhotoProtocol {
+                photo.checkCache()
+                self.photos.append(photo)
+            }
         }
     }
-    
-    public convenience init(originImage:UIImage, photos:[SKPhoto], animatedFromView:UIView) {
+
+    public convenience init(originImage:UIImage, photos:[AnyObject], animatedFromView:UIView) {
         self.init(nibName: nil, bundle: nil)
         self.senderOriginImage = originImage
         self.senderViewForAnimation = animatedFromView
-        for photo in photos{
-            photo.checkCache()
-            self.photos.append(photo)
+        for anyObject in photos{
+            if let photo = anyObject as? SKPhotoProtocol {
+                photo.checkCache()
+                self.photos.append(photo)
+            }
         }
     }
     
@@ -255,7 +259,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
     
     // MARK: - notification
     public func handleSKPhotoLoadingDidEndNotification(notification: NSNotification){
-        let photo = notification.object as! SKPhoto
+        let photo = notification.object as! SKPhotoProtocol
         let page = pageDisplayingAtPhoto(photo)
         if page.photo == nil {
             return
@@ -268,7 +272,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
         }
     }
     
-    public func loadAdjacentPhotosIfNecessary(photo: SKPhoto){
+    public func loadAdjacentPhotosIfNecessary(photo: SKPhotoProtocol){
         let page = pageDisplayingAtPhoto(photo)
         let pageIndex = (page.tag - pageIndexTagOffset)
         if currentPageIndex == pageIndex{
@@ -587,7 +591,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
         return result
     }
     
-    public func imageForPhoto(photo: SKPhoto)-> UIImage?{
+    public func imageForPhoto(photo: SKPhotoProtocol)-> UIImage?{
         if photo.underlyingImage != nil {
             return photo.underlyingImage
         } else {
@@ -623,7 +627,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
         hideControlsAfterDelay()
     }
     
-    public func photoAtIndex(index: Int) -> SKPhoto {
+    public func photoAtIndex(index: Int) -> SKPhotoProtocol {
         return photos[index]
     }
     
@@ -710,10 +714,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate{
         return thePage
     }
     
-    public func pageDisplayingAtPhoto(photo: SKPhoto) -> SKZoomingScrollView {
+    public func pageDisplayingAtPhoto(photo: SKPhotoProtocol) -> SKZoomingScrollView {
         var thePage:SKZoomingScrollView = SKZoomingScrollView()
         for page in visiblePages {
-            if page.photo == photo {
+            if page.photo === photo {
                 thePage = page
                 break
             }

--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -11,7 +11,7 @@ import UIKit
 public class SKZoomingScrollView:UIScrollView, UIScrollViewDelegate, SKDetectingViewDelegate, SKDetectingImageViewDelegate{
     
     weak var photoBrowser:SKPhotoBrowser!
-    var photo:SKPhoto!{
+    var photo:SKPhotoProtocol!{
         didSet{
             photoImageView.image = nil
             displayImage()


### PR DESCRIPTION
IDMPhotoBrowser allows the usage of another image object, besides IDMPhoto, as long as it conforms to the IDMPhoto protocol.  This allows greater flexibility on loading of images (specifically in the `loadUnderlyingImageAndNotify` function.

I needed this functionality, so I attempted a basic implementation.  I confirmed it works with the example (and it works in my app as well).  A few notes:

* I had to name it `SKPhotoProtocol` cause swift wouldn't let a protocol and a class be named the same (unlike IDMPhoto)
* I had to change the initializers to be arrays of AnyObject, because swift won't let you have arrays of objects conforming to a protocol.  The compiler is ok, but on run you get a 'array cannot be bridged from Objective C' error.

Look ok?   Thoughts?