### PR TITLE
Better user experience 

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -589,7 +589,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate, UIActionShe
         modalTransitionStyle = .CrossDissolve
         senderViewForAnimation?.hidden = false
         prepareForClosePhotoBrowser()
-        dismissViewControllerAnimated(true){
+        dismissViewControllerAnimated(false){
             self.delegate?.didDismissAtPageIndex?(self.currentPageIndex)
         }
     }

--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -225,7 +225,9 @@ public class SKZoomingScrollView:UIScrollView, UIScrollViewDelegate, SKDetecting
     }
     
     func handleDoubleTap(view: UIView, touch: UITouch) {
-        // nothing to do
+        var point = self.convertPoint(touch.locationInView(view), toView: self.photoImageView)
+        point.y = 0
+        handleDoubleTap(point)
     }
     
     // MARK: - SKDetectingImageViewDelegate


### PR DESCRIPTION
Better user experience
- Fix delay after close animation, set flag to false in `dismissPhotoBrowser` function
```swift
dismissViewControllerAnimated(false) {
    self.delegate?.didDismissAtPageIndex?(self.currentPageIndex)
}
```
- Add image scale handler when double tap the DetectingView.
