### PR TITLE
CustomCloseButton (customDoneButton)

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -157,6 +157,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         modalTransitionStyle = UIModalTransitionStyle.CrossDissolve
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "handleSKPhotoLoadingDidEndNotification:", name: SKPHOTO_LOADING_DID_END_NOTIFICATION, object: nil)
+        
+        // it change delete button frame while rotation of device
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "changeOrientation", name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
     }
     
     // MARK: - override
@@ -241,9 +244,6 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         
         // transition (this must be last call of view did load.)
         performPresentAnimation()
-        
-        // it change delete button frame while rotation of device
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "changeOrientation", name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
     }
     
     public override func viewWillAppear(animated: Bool) {

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -68,6 +68,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     public var customCloseButtonImage: UIImage!
     public var customCloseButtonEdgeInsets: UIEdgeInsets!
     public var customCloseButtonConstraints: [NSLayoutConstraint]!
+    private var customCloseButtonHideOldFrame: CGRect!
+    private var customCloseButtonShowOldFrame: CGRect!
     
     private var deleteButton: UIButton!
     private var deleteButtonShowFrame: CGRect! //= CGRect(x: UIScreen.mainScreen().bounds.size.width - 44 - 5, y: 5, width: 44, height: 44)
@@ -91,6 +93,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     private var isViewActive: Bool = false
     private var isPerformingLayout: Bool = false
     private var isStatusBarOriginallyHidden: Bool = false
+    private var startOrientation: Int!
     
     // scroll property
     private var firstX: CGFloat = 0.0
@@ -222,9 +225,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         
         toolCounterButton = UIBarButtonItem(customView: toolCounterLabel)
         
-        // close
-        
-        // delete
+        // starting setting
+        setStartupValue()
         setCustomSetting()
         setSettingCloseButton()
         setSettingDeleteButton()
@@ -289,6 +291,15 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         } else {
             return areControlsHidden()
         }
+    }
+    
+    // MARK: - set startap values
+    private func setStartupValue() {
+        if customCloseButtonHideFrame != nil && customCloseButtonShowFrame != nil {
+            customCloseButtonHideOldFrame = customCloseButtonHideFrame
+            customCloseButtonShowOldFrame = customCloseButtonShowFrame
+        }
+        startOrientation = UIApplication.sharedApplication().statusBarOrientation.rawValue
     }
     
     // MARK: - setting of buttons
@@ -1060,9 +1071,41 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         setControlsHidden(true, animated: false, permanent: false)
         deleteButtonShowFrame = CGRect(x: view.frame.width - 39, y: 5, width: 44, height: 44)
         deleteButtonHideFrame = CGRect(x: view.frame.width - 39, y: -20, width: 44, height: 44)
-        if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
-            
+        if displayCustomCloseButton == true {
+            if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
+                switch startOrientation {
+                case 1, 2:
+                    changeCustomPortraitFrameAfterRotation()
+                case 3, 4:
+                    changeCustomLandscapeFrameAfterRotation()
+                default: break
+                }
+            }
         }
         setControlsHidden(false, animated: false, permanent: false)
+    }
+    
+    private func changeCustomPortraitFrameAfterRotation() {
+        if UIApplication.sharedApplication().statusBarOrientation.isLandscape {
+            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x * 2, y: customCloseButtonShowOldFrame.origin.y / 2, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
+            
+            customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x * 2, y: customCloseButtonHideOldFrame.origin.y / 2, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
+        } else {
+            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x, y: customCloseButtonShowOldFrame.origin.y, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
+            
+            customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x, y: customCloseButtonHideOldFrame.origin.y, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
+        }
+    }
+    
+    private func changeCustomLandscapeFrameAfterRotation() {
+        if UIApplication.sharedApplication().statusBarOrientation.isPortrait {
+            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x / 2, y: customCloseButtonShowOldFrame.origin.y * 2, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
+            
+            customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x / 2, y: customCloseButtonHideOldFrame.origin.y * 2, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
+        } else {
+            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x, y: customCloseButtonShowOldFrame.origin.y, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
+            
+            customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x, y: customCloseButtonHideOldFrame.origin.y, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
+        }
     }
 }

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -1073,12 +1073,14 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         deleteButtonHideFrame = CGRect(x: view.frame.width - 39, y: -20, width: 44, height: 44)
         if displayCustomCloseButton == true {
             if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
-                switch startOrientation {
-                case 1, 2:
-                    changeCustomPortraitFrameAfterRotation()
-                case 3, 4:
-                    changeCustomLandscapeFrameAfterRotation()
-                default: break
+                if customCloseButtonConstraints == nil {
+                    switch startOrientation {
+                    case 1, 2:
+                        changeCustomPortraitFrameAfterRotation()
+                    case 3, 4:
+                        changeCustomLandscapeFrameAfterRotation()
+                    default: break
+                    }
                 }
             }
         }
@@ -1101,7 +1103,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         if UIApplication.sharedApplication().statusBarOrientation.isPortrait {
             customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x / 2, y: customCloseButtonShowOldFrame.origin.y * 2, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
             
-            customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x / 2, y: customCloseButtonHideOldFrame.origin.y * 2, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
+            customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x / 2, y: customCloseButtonHideOldFrame.origin.y * 2 - customCloseButtonShowOldFrame.height / 2, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
         } else {
             customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x, y: customCloseButtonShowOldFrame.origin.y, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
             

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -321,6 +321,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             closeButtonHideFrame = CGRect(x: 5, y: -20, width: 44, height: 44)
             closeButtonShowFrame = CGRect(x: 5, y: 5, width: 44, height: 44)
             view.addSubview(closeButton)
+            closeButton.translatesAutoresizingMaskIntoConstraints = true
+            closeButton.autoresizingMask = [.FlexibleBottomMargin, .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleTopMargin]
         }
     }
     
@@ -1073,8 +1075,12 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     // MARK: - device rotation
     @objc private func changeOrientation() {
         //        setControlsHidden(true, animated: false, permanent: false)
-        //        deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
-        //        deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
+        // FIXME: - when we will to resolve this probleb https://github.com/suzuki-0000/SKPhotoBrowser/issues/22  it will need to remove
+        deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
+        deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
+        
+        //        customCloseButtonShowFrame = customCloseButtonShowOldFrame
+        //        customCloseButtonHideFrame = customCloseButtonHideOldFrame
         //        if displayCustomCloseButton == true {
         //            if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
         //                if customCloseButtonConstraints == nil {

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -241,6 +241,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         
         // transition (this must be last call of view did load.)
         performPresentAnimation()
+        
+        // it change delete button frame while rotation of device
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "changeOrientation", name: UIApplicationDidChangeStatusBarOrientationNotification, object: nil)
     }
     
     public override func viewWillAppear(animated: Bool) {
@@ -1051,5 +1054,13 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     
     public func scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
         isEndAnimationByToolBar = true
+    }
+    
+    // MARK: - device rotation
+    @objc private func changeOrientation() {
+        setControlsHidden(true, animated: false, permanent: false)
+        deleteButtonShowFrame = CGRect(x: view.frame.width - 39, y: 5, width: 44, height: 44)
+        deleteButtonHideFrame = CGRect(x: view.frame.width - 39, y: -20, width: 44, height: 44)
+        setControlsHidden(false, animated: false, permanent: false)
     }
 }

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -355,8 +355,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     private func setSettingDeleteButton() {
         if displayDeleteButton == true {
             deleteButton = UIButton(type: .Custom)
-            deleteButtonShowFrame = CGRect(x: view.frame.width - 39, y: 5, width: 44, height: 44)
-            deleteButtonHideFrame = CGRect(x: view.frame.width - 39, y: -20, width: 44, height: 44)
+            deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
+            deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
             let image = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_delete_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
             deleteButton.imageEdgeInsets = UIEdgeInsets(top: 15.25, left: 15.25, bottom: 15.25, right: 15.25)
             deleteButton.setImage(image, forState: .Normal)
@@ -1069,8 +1069,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     // MARK: - device rotation
     @objc private func changeOrientation() {
         setControlsHidden(true, animated: false, permanent: false)
-        deleteButtonShowFrame = CGRect(x: view.frame.width - 39, y: 5, width: 44, height: 44)
-        deleteButtonHideFrame = CGRect(x: view.frame.width - 39, y: -20, width: 44, height: 44)
+        deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
+        deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
         if displayCustomCloseButton == true {
             if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
                 if customCloseButtonConstraints == nil {

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -1087,9 +1087,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         setControlsHidden(false, animated: false, permanent: false)
     }
     
+    // FIXME: - there
     private func changeCustomPortraitFrameAfterRotation() {
         if UIApplication.sharedApplication().statusBarOrientation.isLandscape {
-            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x * 2, y: customCloseButtonShowOldFrame.origin.y / 2, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
+            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x * 2, y: customCloseButtonShowOldFrame.origin.y / 2 + customCloseButtonShowOldFrame.height / 4, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
             
             customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x * 2, y: customCloseButtonHideOldFrame.origin.y / 2, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
         } else {
@@ -1101,7 +1102,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     
     private func changeCustomLandscapeFrameAfterRotation() {
         if UIApplication.sharedApplication().statusBarOrientation.isPortrait {
-            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x / 2, y: customCloseButtonShowOldFrame.origin.y * 2, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
+            customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x / 2, y: customCloseButtonShowOldFrame.origin.y * 2 -  customCloseButtonShowOldFrame.height / 2, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)
             
             customCloseButtonHideFrame = CGRect(x: customCloseButtonHideOldFrame.origin.x / 2, y: customCloseButtonHideOldFrame.origin.y * 2 - customCloseButtonShowOldFrame.height / 2, width: customCloseButtonHideOldFrame.width, height: customCloseButtonHideOldFrame.height)
         } else {

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -41,7 +41,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     public var disableVerticalSwipe: Bool = false
     public var isForceStatusBarHidden: Bool = false
     public var displayDeleteButton = false
-
+    public var displayCloseButton = true // default is true
+    
     // actions
     private var activityViewController: UIActivityViewController!
     
@@ -55,9 +56,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     private var toolNextButton: UIBarButtonItem!
     private var pagingScrollView: UIScrollView!
     private var panGesture: UIPanGestureRecognizer!
-    private var doneButton: UIButton!
-    private var doneButtonShowFrame: CGRect = CGRect(x: 5, y: 5, width: 44, height: 44)
-    private var doneButtonHideFrame: CGRect = CGRect(x: 5, y: -20, width: 44, height: 44)
+    private var closeButton: UIButton!
+    private var closeButtonShowFrame: CGRect! //= CGRect(x: 5, y: 5, width: 44, height: 44)
+    private var closeButtonHideFrame: CGRect! //= CGRect(x: 5, y: -20, width: 44, height: 44)
     
     private var deleteButton: UIButton!
     private var deleteButtonShowFrame: CGRect! //= CGRect(x: UIScreen.mainScreen().bounds.size.width - 44 - 5, y: 5, width: 44, height: 44)
@@ -118,7 +119,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             }
         }
     }
-
+    
     public convenience init(originImage: UIImage, photos: [AnyObject], animatedFromView: UIView) {
         self.init(nibName: nil, bundle: nil)
         self.senderOriginImage = originImage
@@ -208,17 +209,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         toolCounterButton = UIBarButtonItem(customView: toolCounterLabel)
         
         // close
-        let doneImage = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_close_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
-        doneButton = UIButton(type: UIButtonType.Custom)
-        doneButton.setImage(doneImage, forState: UIControlState.Normal)
-        doneButton.frame = doneButtonHideFrame
-        doneButton.imageEdgeInsets = UIEdgeInsetsMake(15.25, 15.25, 15.25, 15.25)
-        doneButton.backgroundColor = .clearColor()
-        doneButton.addTarget(self, action: "doneButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
-        doneButton.alpha = 0.0
-        view.addSubview(doneButton)
         
         // delete
+        setSettingCloseButton()
         setSettingDeleteButton()
         
         // action button
@@ -280,8 +273,26 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             return areControlsHidden()
         }
     }
-
-    // MARK: - setting of delete button
+    
+    // MARK: - setting of buttons
+    
+    private func setSettingCloseButton() {
+        if displayCloseButton == true {
+            let bundle = NSBundle(forClass: SKPhotoBrowser.self)
+            let doneImage = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_close_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
+            closeButton = UIButton(type: UIButtonType.Custom)
+            closeButton.setImage(doneImage, forState: UIControlState.Normal)
+            // TODO: - close frame
+            //            closeButton.frame = closeButtonHideFrame
+            closeButton.imageEdgeInsets = UIEdgeInsetsMake(15.25, 15.25, 15.25, 15.25)
+            closeButton.backgroundColor = .clearColor()
+            closeButton.addTarget(self, action: "doneButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
+            closeButtonHideFrame = CGRect(x: 5, y: -20, width: 44, height: 44)
+            closeButtonShowFrame = CGRect(x: 5, y: 5, width: 44, height: 44)
+            closeButton.alpha = 0.0
+            view.addSubview(closeButton)
+        }
+    }
     
     private func setSettingDeleteButton() {
         let bundle = NSBundle(forClass: SKPhotoBrowser.self)
@@ -429,7 +440,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         let navHeight = navigationController?.navigationBar.frame.size.height ?? 44
         
         return CGRect(x: pageFrame.origin.x, y: pageFrame.size.height - captionSize.height - navHeight,
-                      width: pageFrame.size.width, height: captionSize.height)
+            width: pageFrame.size.width, height: captionSize.height)
     }
     
     public func frameForPageAtIndex(index: Int) -> CGRect {
@@ -482,7 +493,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         toolPreviousButton.enabled = (currentPageIndex > 0)
         toolNextButton.enabled = (currentPageIndex < numberOfPhotos - 1)
     }
-   
+    
     // MARK: - panGestureRecognized
     public func panGestureRecognized(sender: UIPanGestureRecognizer) {
         
@@ -506,7 +517,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         
         translatedPoint = CGPoint(x: firstX, y: firstY + translatedPoint.y)
         scrollView.center = translatedPoint
-     
+        
         view.opaque = true
         
         // gesture end
@@ -535,8 +546,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
                 UIView.commitAnimations()
                 
                 dismissPhotoBrowser()
-             } else {
-            
+            } else {
+                
                 // Continue Showing View
                 isDraggingPhoto = false
                 setNeedsStatusBarAppearanceUpdate()
@@ -593,8 +604,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             UIView.animateWithDuration(animationDuration,
                 animations: { () -> Void in
                     self.resizableImageView.frame = finalImageViewFrame
-                    self.doneButton.alpha = 1.0
-                    self.doneButton.frame = self.doneButtonShowFrame
+                    if self.displayCloseButton == true {
+                        self.closeButton.alpha = 1.0
+                        self.closeButton.frame = self.closeButtonShowFrame
+                    }
                     if self.displayDeleteButton == true {
                         self.deleteButton.alpha = 1.0
                         self.deleteButton.frame = self.deleteButtonShowFrame
@@ -615,8 +628,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             
             UIView.animateWithDuration(animationDuration,
                 animations: { () -> Void in
-                    self.doneButton.alpha = 1.0
-                    self.doneButton.frame = self.doneButtonShowFrame
+                    if self.displayCloseButton == true {
+                        self.closeButton.alpha = 1.0
+                        self.closeButton.frame = self.closeButtonShowFrame
+                    }
                     if self.displayDeleteButton == true {
                         self.deleteButton.alpha = 1.0
                         self.deleteButton.frame = self.deleteButtonShowFrame
@@ -663,7 +678,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             self.delegate?.didDismissAtPageIndex?(self.currentPageIndex)
         }
     }
-
+    
     //MARK: - image
     private func getImageFromView(sender: UIView) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(sender.frame.size, true, 2.0)
@@ -743,7 +758,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         if lastIndex > numberOfPhotos - 1 {
             lastIndex = numberOfPhotos - 1
         }
-       
+        
         for var index = firstIndex; index <= lastIndex; index++ {
             if isDisplayingPageForIndex(index) {
                 continue
@@ -794,8 +809,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         var thePage: SKZoomingScrollView = SKZoomingScrollView()
         for page in visiblePages {
             if (page.tag - pageIndexTagOffset) == index {
-               thePage = page
-               break
+                thePage = page
+                break
             }
         }
         return thePage
@@ -850,8 +865,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
                 let alpha: CGFloat = hidden ? 0.0 : 1.0
                 self.toolBar.alpha = alpha
                 self.toolBar.frame = hidden ? self.frameForToolbarHideAtOrientation() : self.frameForToolbarAtOrientation()
-                self.doneButton.alpha = alpha
-                self.doneButton.frame = hidden ? self.doneButtonHideFrame : self.doneButtonShowFrame
+                if self.displayCloseButton == true {
+                    self.closeButton.alpha = alpha
+                    self.closeButton.frame = hidden ? self.closeButtonHideFrame : self.closeButtonShowFrame
+                }
                 if self.displayDeleteButton == true {
                     self.deleteButton.alpha = alpha
                     self.deleteButton.frame = hidden ? self.deleteButtonHideFrame : self.deleteButtonShowFrame
@@ -882,7 +899,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             dismissPhotoBrowser()
         }
     }
-
+    
     // MARK: Action Button
     public func actionButtonPressed() {
         let photo = photoAtIndex(currentPageIndex)

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -342,13 +342,16 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             }
             if customCloseButtonEdgeInsets != nil {
                 customCloseButton.imageEdgeInsets = customCloseButtonEdgeInsets
-            } else {
-                customCloseButton.imageEdgeInsets = UIEdgeInsets(top: 15.25, left: 15.25, bottom: 15.25, right: 15.25)
             }
             if customCloseButtonConstraints != nil {
                 customCloseButton.addConstraints(customCloseButtonConstraints)
             }
+            
+            customCloseButton.translatesAutoresizingMaskIntoConstraints = true
             view.addSubview(customCloseButton)
+            customCloseButton.autoresizingMask = [.FlexibleBottomMargin, .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleTopMargin]
+            customCloseButton.center = CGPoint(x: CGRectGetMidX(view.bounds), y: CGRectGetMidY(view.bounds))
+            
         }
     }
     
@@ -1071,23 +1074,23 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         setControlsHidden(true, animated: false, permanent: false)
         deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
         deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
-        if displayCustomCloseButton == true {
-            if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
-                if customCloseButtonConstraints == nil {
-                    switch startOrientation {
-                    case 1, 2:
-                        changeCustomPortraitFrameAfterRotation()
-                    case 3, 4:
-                        changeCustomLandscapeFrameAfterRotation()
-                    default: break
-                    }
-                }
-            }
-        }
+        //        if displayCustomCloseButton == true {
+        //            if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
+        //                if customCloseButtonConstraints == nil {
+        //                    switch startOrientation {
+        //                    case 1, 2:
+        //                        changeCustomPortraitFrameAfterRotation()
+        //                    case 3, 4:
+        //                        changeCustomLandscapeFrameAfterRotation()
+        //                    default: break
+        //                    }
+        //                }
+        //            }
+        //        }
         setControlsHidden(false, animated: false, permanent: false)
     }
     
-    // FIXME: - there
+    // FIXME: - Maybe it will be needed in the future
     private func changeCustomPortraitFrameAfterRotation() {
         if UIApplication.sharedApplication().statusBarOrientation.isLandscape {
             customCloseButtonShowFrame = CGRect(x: customCloseButtonShowOldFrame.origin.x * 2, y: customCloseButtonShowOldFrame.origin.y / 2 + customCloseButtonShowOldFrame.height / 4, width: customCloseButtonShowOldFrame.width, height: customCloseButtonShowOldFrame.height)

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -42,6 +42,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     public var isForceStatusBarHidden: Bool = false
     public var displayDeleteButton = false
     public var displayCloseButton = true // default is true
+    public var displayCustomCloseButton = false // if it is true displayCloseButton will be false
     
     // actions
     private var activityViewController: UIActivityViewController!
@@ -59,6 +60,13 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     private var closeButton: UIButton!
     private var closeButtonShowFrame: CGRect! //= CGRect(x: 5, y: 5, width: 44, height: 44)
     private var closeButtonHideFrame: CGRect! //= CGRect(x: 5, y: -20, width: 44, height: 44)
+    
+    // custom close button
+    private var customCloseButton: UIButton!
+    public var customCloseButtonShowFrame: CGRect!
+    public var customCloseButtonHideFrame: CGRect!
+    public var customCloseButtonImage: UIImage!
+    public var customCloseButtonEdgeInsets: UIEdgeInsets!
     
     private var deleteButton: UIButton!
     private var deleteButtonShowFrame: CGRect! //= CGRect(x: UIScreen.mainScreen().bounds.size.width - 44 - 5, y: 5, width: 44, height: 44)
@@ -92,6 +100,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     
     // delegate
     public weak var delegate: SKPhotoBrowserDelegate?
+    
+    // helpers which often used
+    private let bundle = NSBundle(forClass: SKPhotoBrowser.self)
     
     // photos
     var photos: [SKPhotoProtocol] = [SKPhotoProtocol]()
@@ -211,8 +222,11 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         // close
         
         // delete
+        setCustomSetting()
         setSettingCloseButton()
         setSettingDeleteButton()
+        setSettingCustomCloseButton()
+        
         
         // action button
         toolActionButton = UIBarButtonItem(barButtonSystemItem: .Action, target: self, action: "actionButtonPressed")
@@ -275,27 +289,52 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     }
     
     // MARK: - setting of buttons
+    // This function should be at the beginning of the other functions
+    private func setCustomSetting() {
+        if displayCustomCloseButton == true {
+            displayCloseButton = false
+        }
+    }
     
     private func setSettingCloseButton() {
         if displayCloseButton == true {
-            let bundle = NSBundle(forClass: SKPhotoBrowser.self)
             let doneImage = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_close_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
             closeButton = UIButton(type: UIButtonType.Custom)
             closeButton.setImage(doneImage, forState: UIControlState.Normal)
-            // TODO: - close frame
-            //            closeButton.frame = closeButtonHideFrame
             closeButton.imageEdgeInsets = UIEdgeInsetsMake(15.25, 15.25, 15.25, 15.25)
             closeButton.backgroundColor = .clearColor()
-            closeButton.addTarget(self, action: "doneButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
+            closeButton.addTarget(self, action: "closeButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
             closeButtonHideFrame = CGRect(x: 5, y: -20, width: 44, height: 44)
             closeButtonShowFrame = CGRect(x: 5, y: 5, width: 44, height: 44)
-            closeButton.alpha = 0.0
             view.addSubview(closeButton)
         }
     }
     
+    private func setSettingCustomCloseButton() {
+        if displayCustomCloseButton == true {
+            let closeImage = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_close_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
+            customCloseButton = UIButton(type: .Custom)
+            customCloseButton.addTarget(self, action: "closeButtonPressed:", forControlEvents: .TouchUpInside)
+            customCloseButton.backgroundColor = .clearColor()
+            if customCloseButtonImage != nil {
+                customCloseButton.setImage(customCloseButtonImage, forState: .Normal)
+            } else {
+                customCloseButton.setImage(closeImage, forState: .Normal)
+            }
+            // If another developer has not set their values
+            if customCloseButtonShowFrame == nil && customCloseButtonHideFrame == nil {
+                customCloseButtonShowFrame = CGRect(x: 5, y: 5, width: 44, height: 44)
+                customCloseButtonHideFrame = CGRect(x: 5, y: -20, width: 44, height: 44)
+            }
+            if customCloseButtonEdgeInsets != nil {
+                customCloseButton.imageEdgeInsets = customCloseButtonEdgeInsets
+            }
+            customCloseButton.alpha = 0.0
+            view.addSubview(customCloseButton)
+        }
+    }
+    
     private func setSettingDeleteButton() {
-        let bundle = NSBundle(forClass: SKPhotoBrowser.self)
         if displayDeleteButton == true {
             deleteButton = UIButton(type: .Custom)
             deleteButtonShowFrame = CGRect(x: view.frame.width - 39, y: 5, width: 44, height: 44)
@@ -612,6 +651,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
                         self.deleteButton.alpha = 1.0
                         self.deleteButton.frame = self.deleteButtonShowFrame
                     }
+                    if self.displayCustomCloseButton == true {
+                        self.customCloseButton.alpha = 1.0
+                        self.customCloseButton.frame = self.customCloseButtonShowFrame
+                    }
                 },
                 completion: { (Bool) -> Void in
                     self.view.alpha = 1.0
@@ -635,6 +678,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
                     if self.displayDeleteButton == true {
                         self.deleteButton.alpha = 1.0
                         self.deleteButton.frame = self.deleteButtonShowFrame
+                    }
+                    if self.displayCustomCloseButton == true {
+                        self.customCloseButton.alpha = 1.0
+                        self.customCloseButton.frame = self.customCloseButtonShowFrame
                     }
                 },
                 completion: { (Bool) -> Void in
@@ -873,6 +920,10 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
                     self.deleteButton.alpha = alpha
                     self.deleteButton.frame = hidden ? self.deleteButtonHideFrame : self.deleteButtonShowFrame
                 }
+                if self.displayCustomCloseButton == true {
+                    self.customCloseButton.alpha = alpha
+                    self.customCloseButton.frame = hidden ? self.customCloseButtonHideFrame : self.customCloseButtonShowFrame
+                }
                 for v in captionViews {
                     v.alpha = alpha
                 }
@@ -892,7 +943,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     }
     
     // MARK: - Button
-    public func doneButtonPressed(sender: UIButton) {
+    public func closeButtonPressed(sender: UIButton) {
         if currentPageIndex == initialPageIndex {
             performCloseAnimationWithScrollView(pageDisplayedAtIndex(currentPageIndex))
         } else {

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -62,11 +62,12 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     private var closeButtonHideFrame: CGRect! //= CGRect(x: 5, y: -20, width: 44, height: 44)
     
     // custom close button
-    private var customCloseButton: UIButton!
+    private(set) var customCloseButton: UIButton!
     public var customCloseButtonShowFrame: CGRect!
     public var customCloseButtonHideFrame: CGRect!
     public var customCloseButtonImage: UIImage!
     public var customCloseButtonEdgeInsets: UIEdgeInsets!
+    public var customCloseButtonConstraints: [NSLayoutConstraint]!
     
     private var deleteButton: UIButton!
     private var deleteButtonShowFrame: CGRect! //= CGRect(x: UIScreen.mainScreen().bounds.size.width - 44 - 5, y: 5, width: 44, height: 44)
@@ -316,20 +317,24 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             customCloseButton = UIButton(type: .Custom)
             customCloseButton.addTarget(self, action: "closeButtonPressed:", forControlEvents: .TouchUpInside)
             customCloseButton.backgroundColor = .clearColor()
+            // If another developer has not set their values
             if customCloseButtonImage != nil {
                 customCloseButton.setImage(customCloseButtonImage, forState: .Normal)
             } else {
                 customCloseButton.setImage(closeImage, forState: .Normal)
             }
-            // If another developer has not set their values
             if customCloseButtonShowFrame == nil && customCloseButtonHideFrame == nil {
                 customCloseButtonShowFrame = CGRect(x: 5, y: 5, width: 44, height: 44)
                 customCloseButtonHideFrame = CGRect(x: 5, y: -20, width: 44, height: 44)
             }
             if customCloseButtonEdgeInsets != nil {
                 customCloseButton.imageEdgeInsets = customCloseButtonEdgeInsets
+            } else {
+                customCloseButton.imageEdgeInsets = UIEdgeInsets(top: 15.25, left: 15.25, bottom: 15.25, right: 15.25)
             }
-            customCloseButton.alpha = 0.0
+            if customCloseButtonConstraints != nil {
+                customCloseButton.addConstraints(customCloseButtonConstraints)
+            }
             view.addSubview(customCloseButton)
         }
     }

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -193,7 +193,6 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         }
         
         // arrows:back
-        let bundle = NSBundle(forClass: SKPhotoBrowser.self)
         let previousBtn = UIButton(type: .Custom)
         let previousImage = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_back_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
         previousBtn.frame = CGRect(x: 0, y: 0, width: 44, height: 44)
@@ -1061,6 +1060,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         setControlsHidden(true, animated: false, permanent: false)
         deleteButtonShowFrame = CGRect(x: view.frame.width - 39, y: 5, width: 44, height: 44)
         deleteButtonHideFrame = CGRect(x: view.frame.width - 39, y: -20, width: 44, height: 44)
+        if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
+            
+        }
         setControlsHidden(false, animated: false, permanent: false)
     }
 }

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -350,7 +350,6 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             customCloseButton.translatesAutoresizingMaskIntoConstraints = true
             view.addSubview(customCloseButton)
             customCloseButton.autoresizingMask = [.FlexibleBottomMargin, .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleTopMargin]
-            customCloseButton.center = CGPoint(x: CGRectGetMidX(view.bounds), y: CGRectGetMidY(view.bounds))
             
         }
     }
@@ -366,6 +365,8 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             deleteButton.addTarget(self, action: "deleteButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
             deleteButton.alpha = 0.0
             view.addSubview(deleteButton)
+            deleteButton.translatesAutoresizingMaskIntoConstraints = true
+            deleteButton.autoresizingMask = [.FlexibleBottomMargin, .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleTopMargin]
         }
     }
     
@@ -1071,9 +1072,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     
     // MARK: - device rotation
     @objc private func changeOrientation() {
-        setControlsHidden(true, animated: false, permanent: false)
-        deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
-        deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
+        //        setControlsHidden(true, animated: false, permanent: false)
+        //        deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
+        //        deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
         //        if displayCustomCloseButton == true {
         //            if customCloseButtonShowFrame != nil && customCloseButtonHideFrame != nil {
         //                if customCloseButtonConstraints == nil {
@@ -1087,7 +1088,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         //                }
         //            }
         //        }
-        setControlsHidden(false, animated: false, permanent: false)
+        //        setControlsHidden(false, animated: false, permanent: false)
     }
     
     // FIXME: - Maybe it will be needed in the future

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -62,7 +62,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     private var closeButtonHideFrame: CGRect! //= CGRect(x: 5, y: -20, width: 44, height: 44)
     
     // custom close button
-    private(set) var customCloseButton: UIButton!
+    private var customCloseButton: UIButton!
     public var customCloseButtonShowFrame: CGRect!
     public var customCloseButtonHideFrame: CGRect!
     public var customCloseButtonImage: UIImage!
@@ -315,7 +315,11 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             let doneImage = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_close_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
             closeButton = UIButton(type: UIButtonType.Custom)
             closeButton.setImage(doneImage, forState: UIControlState.Normal)
-            closeButton.imageEdgeInsets = UIEdgeInsetsMake(15.25, 15.25, 15.25, 15.25)
+            if UI_USER_INTERFACE_IDIOM() == .Phone {
+                closeButton.imageEdgeInsets = UIEdgeInsetsMake(15.25, 15.25, 15.25, 15.25)
+            } else {
+                closeButton.imageEdgeInsets = UIEdgeInsetsMake(12, 12, 12, 12)
+            }
             closeButton.backgroundColor = .clearColor()
             closeButton.addTarget(self, action: "closeButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
             closeButtonHideFrame = CGRect(x: 5, y: -20, width: 44, height: 44)
@@ -362,7 +366,11 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
             deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
             let image = UIImage(named: "SKPhotoBrowser.bundle/images/btn_common_delete_wh", inBundle: bundle, compatibleWithTraitCollection: nil) ?? UIImage()
-            deleteButton.imageEdgeInsets = UIEdgeInsets(top: 15.25, left: 15.25, bottom: 15.25, right: 15.25)
+            if UI_USER_INTERFACE_IDIOM() == .Phone {
+                deleteButton.imageEdgeInsets = UIEdgeInsets(top: 15.25, left: 15.25, bottom: 15.25, right: 15.25)
+            } else {
+                deleteButton.imageEdgeInsets = UIEdgeInsetsMake(12.3, 12.3, 12.3, 12.3)
+            }
             deleteButton.setImage(image, forState: .Normal)
             deleteButton.addTarget(self, action: "deleteButtonPressed:", forControlEvents: UIControlEvents.TouchUpInside)
             deleteButton.alpha = 0.0
@@ -1075,7 +1083,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     // MARK: - device rotation
     @objc private func changeOrientation() {
         //        setControlsHidden(true, animated: false, permanent: false)
-        // FIXME: - when we will to resolve this probleb https://github.com/suzuki-0000/SKPhotoBrowser/issues/22  it will need to remove
+        // FIXME: - when we will to resolve this problem https://github.com/suzuki-0000/SKPhotoBrowser/issues/22  it will need to remove
         deleteButtonShowFrame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 44)
         deleteButtonHideFrame = CGRect(x: view.frame.width - 44, y: -20, width: 44, height: 44)
         


### PR DESCRIPTION
Hello @suzuki-0000  I made a button closure for easy tuning. If another developer is going to use CustomCloseButton original closeButton is turned off. 
https://www.dropbox.com/s/6ouv7nf8wa3wzki/CustomCloseButton.mov?dl=0

It is easy to setting. It is my example how to use customCloseButton
```
 browser.displayCustomCloseButton = true
        browser.customCloseButtonImage = UIImage(named: "closeButton.png")
        browser.customCloseButtonShowFrame = CGRect(x: view.frame.width / 2 - 25, y: view.frame.height - 58, width: 50, height: 50)
        browser.customCloseButtonHideFrame = CGRect(x: view.frame.width / 2 - 25, y: view.frame.height + 58, width: 50, height: 50)
        presentViewController(browser, animated: true, completion: nil)
```