### PR TITLE
Added delegate method to allow animating closing to other frames

### DIFF
--- a/SKPhotoBrowserExample/SKPhotoBrowserExample/ViewController.swift
+++ b/SKPhotoBrowserExample/SKPhotoBrowserExample/ViewController.swift
@@ -96,7 +96,8 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
     }
     
     func willDismissAtPageIndex(index: Int) {
-        // do some handle if you need
+        collectionView.visibleCells().forEach({$0.hidden = false})
+        collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: index, inSection: 0))?.hidden = true
     }
    
     func willShowActionSheet(photoIndex: Int) {
@@ -104,7 +105,7 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
     }
     
     func didDismissAtPageIndex(index: Int) {
-        // do some handle if you need
+        collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: index, inSection: 0))?.hidden = false
     }
     
     func didDismissActionSheetWithButtonIndex(buttonIndex: Int, photoIndex: Int) {
@@ -115,6 +116,10 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
         // do some handle if you need
     }
     
+    func viewForPhoto(browser: SKPhotoBrowser, index: Int) -> UIView? {
+        
+        return collectionView.cellForItemAtIndexPath(NSIndexPath(forItem: index, inSection: 0))
+    }
 }
 
 


### PR DESCRIPTION
Added a new delegate method that can ask for the 'new' frame when closing.

This allows two things:
- Update the frame after rotating to transition is correct
- Update the frame when closing on a different cell than the one you started on

I updated the demo to show this option