### PR TITLE
Fixed error while dismissing empty image

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -877,7 +877,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
             width: scrollFrame.width,
             height: scrollFrame.height)
         
-        resizableImageView.image = scrollView.photo?.underlyingImage.rotateImageByOrientation() ?? resizableImageView.image
+        resizableImageView.image = scrollView.photo?.underlyingImage?.rotateImageByOrientation() ?? resizableImageView.image
         resizableImageView.frame = frame
         resizableImageView.alpha = 1.0
         resizableImageView.clipsToBounds = true


### PR DESCRIPTION
When you are trying to close browser with image which is not loaded yet, there is an error unwrapping optional value. Fixed!