### PR TITLE
Using SKPhotoProtocol to enable usage from SKLocalPhoto and SKPhoto

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the code snippet below for an example of how to implement, or example projec
 	
 ```swift
 // add SKPhoto Array from UIImage
-var images = [SKPhoto]()
+var images = [SKPhotoProtocol]()
 let photo = SKPhoto.photoWithImage(UIImage())// add some UIImage
 images.append(photo) 
 
@@ -60,7 +60,7 @@ presentViewController(browser, animated: true, completion: {})
 from web URLs:
 ```swift
 // URL pattern snippet
-var images = [SKPhoto]()
+var images = [SKPhotoProtocol]()
 let photo = SKPhoto.photoWithImageURL("https://placehold.jp/150x150.png")
 photo.shouldCachePhotoURLImage = false // you can use image cache by true(NSCache)
 images.append(photo)
@@ -73,7 +73,7 @@ presentViewController(browser, animated: true, completion: {})
 from local files:
 ```swift
 // images from local files
-var images = [SKLocalPhoto]()
+var images = [SKPhotoProtocol]()
 let photo = SKLocalPhoto.photoWithImageURL("..some_local_path/150x150.png")
 images.append(photo)
 

--- a/SKPhotoBrowser.podspec
+++ b/SKPhotoBrowser.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SKPhotoBrowser"
-  s.version      = "1.8.3"
+  s.version      = "1.8.4"
   s.summary      = "Simple PhotoBrowser/Viewer inspired by facebook, twitter photo browsers written by swift2.0."
   s.homepage     = "https://github.com/suzuki-0000/SKPhotoBrowser"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -203,7 +203,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         setup()
     }
     
-    public convenience init(photos: [SKPhoto]) {
+    public convenience init(photos: [SKPhotoProtocol]) {
         self.init(nibName: nil, bundle: nil)
         for photo in photos {
             photo.checkCache()
@@ -211,7 +211,7 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         }
     }
     
-    public convenience init(originImage: UIImage, photos: [SKPhoto], animatedFromView: UIView) {
+    public convenience init(originImage: UIImage, photos: [SKPhotoProtocol], animatedFromView: UIView) {
         self.init(nibName: nil, bundle: nil)
         self.senderOriginImage = originImage
         self.senderViewForAnimation = animatedFromView

--- a/SKPhotoBrowserExample/SKPhotoBrowserExample/CameraRollViewController.swift
+++ b/SKPhotoBrowserExample/SKPhotoBrowserExample/CameraRollViewController.swift
@@ -102,7 +102,7 @@ class CameraRollViewController: UIViewController, SKPhotoBrowserDelegate, UIColl
         
         func open(images:[UIImage]) {
             
-            let photoImages:[SKPhoto] = images.map({ return SKPhoto.photoWithImage($0) })
+            let photoImages:[SKPhotoProtocol] = images.map({ return SKPhoto.photoWithImage($0) })
             let browser = SKPhotoBrowser(originImage: cell.exampleImageView.image!, photos: photoImages, animatedFromView: cell)
             
             browser.initializePageIndex(indexPath.row)

--- a/SKPhotoBrowserExample/SKPhotoBrowserExample/ViewController.swift
+++ b/SKPhotoBrowserExample/SKPhotoBrowserExample/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
     private var screenHeight: CGFloat { return screenBound.size.height }
 
     @IBOutlet weak var collectionView: UICollectionView!
-    var images = [SKPhoto]()
+    var images = [SKPhotoProtocol]()
     var caption = ["Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
                    "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
                    "It has survived not only five centuries, but also the leap into electronic typesetting",


### PR DESCRIPTION
@barrault01 This fix the usage from SKLocalPhoto, now is possible to use booth.

Instead of create:
```
var images = [SKLocalPhoto]()
var images = [SKPhoto]()
```

Use:
`var images = [SKPhotoProtocol]()`