### PR TITLE
Fixe issue 89

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -203,19 +203,21 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
         setup()
     }
     
-    public convenience init(photos: [SKPhotoProtocol]) {
+    public convenience init(photos: [AnyObject]) {
         self.init(nibName: nil, bundle: nil)
-        for photo in photos {
+        let picutres = photos.flatMap {$0 as? SKPhotoProtocol}
+        for photo in picutres {
             photo.checkCache()
             self.photos.append(photo)
         }
     }
     
-    public convenience init(originImage: UIImage, photos: [SKPhotoProtocol], animatedFromView: UIView) {
+    public convenience init(originImage: UIImage, photos: [AnyObject], animatedFromView: UIView) {
         self.init(nibName: nil, bundle: nil)
         self.senderOriginImage = originImage
         self.senderViewForAnimation = animatedFromView
-        for photo in photos {
+        let picutres = photos.flatMap {$0 as? SKPhotoProtocol}
+        for photo in picutres {
             photo.checkCache()
             self.photos.append(photo)
         }

--- a/SKPhotoBrowserTests/SKPhotoBrowserTests.swift
+++ b/SKPhotoBrowserTests/SKPhotoBrowserTests.swift
@@ -42,14 +42,6 @@ class SKPhotoBrowserTests: XCTestCase {
         images.append(photo)
         let _ = FakeSKPhotoBrowser(photos: images)
     }
-    
-    func testSKPhotoProtocolArray() {
-        var images = [SKPhotoProtocol]()
-        let photo = SKPhoto.photoWithImage(UIImage())// add some UIImage
-        images.append(photo)
-        let _ =  FakeSKPhotoBrowser(photos: images)
-    }
-
 
     func testPerformanceExample() {
         // This is an example of a performance test case.

--- a/SKPhotoBrowserTests/SKPhotoBrowserTests.swift
+++ b/SKPhotoBrowserTests/SKPhotoBrowserTests.swift
@@ -7,6 +7,14 @@
 //
 
 import XCTest
+@testable import SKPhotoBrowser
+
+
+class FakeSKPhotoBrowser : SKPhotoBrowser {
+    override func setup () {
+        
+    }
+}
 
 class SKPhotoBrowserTests: XCTestCase {
     
@@ -19,12 +27,30 @@ class SKPhotoBrowserTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+
     
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testSKPhotoArray() {
+        var images = [SKPhoto]()
+        let photo = SKPhoto.photoWithImage(UIImage())// add some UIImage
+        images.append(photo)
+        let _ = FakeSKPhotoBrowser(photos: images)
     }
     
+    func testSKLocalPhotoArray() {
+        var images = [SKLocalPhoto]()
+        let photo = SKLocalPhoto.photoWithImageURL("")
+        images.append(photo)
+        let _ = FakeSKPhotoBrowser(photos: images)
+    }
+    
+    func testSKPhotoProtocolArray() {
+        var images = [SKPhotoProtocol]()
+        let photo = SKPhoto.photoWithImage(UIImage())// add some UIImage
+        images.append(photo)
+        let _ =  FakeSKPhotoBrowser(photos: images)
+    }
+
+
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measureBlock {


### PR DESCRIPTION
This should fixe: https://github.com/suzuki-0000/SKPhotoBrowser/issues/89
1) I write some test to check if this issue is not happening again
2) The sdk is depending of objc so it is not possible to pass an array of swift objects directly that why the use of AnyObject is required for the moment. 

It will be nice to remove objc dependencies. 