### PR TITLE
fix 2 compile errors on Xcode 7.3.1

### DIFF
--- a/SKPhotoBrowserExample/SKPhotoBrowserExample/CameraRollViewController.swift
+++ b/SKPhotoBrowserExample/SKPhotoBrowserExample/CameraRollViewController.swift
@@ -102,7 +102,7 @@ class CameraRollViewController: UIViewController, SKPhotoBrowserDelegate, UIColl
         
         func open(images:[UIImage]) {
             
-            let photoImages:[SKPhotoProtocol] = images.map({ return SKPhoto.photoWithImage($0) })
+            let photoImages:[SKPhoto] = images.map({ return SKPhoto.photoWithImage($0) })
             let browser = SKPhotoBrowser(originImage: cell.exampleImageView.image!, photos: photoImages, animatedFromView: cell)
             
             browser.initializePageIndex(indexPath.row)

--- a/SKPhotoBrowserExample/SKPhotoBrowserExample/ViewController.swift
+++ b/SKPhotoBrowserExample/SKPhotoBrowserExample/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
     private var screenHeight: CGFloat { return screenBound.size.height }
 
     @IBOutlet weak var collectionView: UICollectionView!
-    var images = [SKPhotoProtocol]()
+    var images = [SKPhoto]()
     var caption = ["Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
                    "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
                    "It has survived not only five centuries, but also the leap into electronic typesetting",


### PR DESCRIPTION
The example project wouldn't compile on Xcode 7.3.1.
error: " cannot convert value of type [SkPhotoProtocol] to to expected argument type [AnyObject] " on
SKPhotoBrowser(_: UIIimage, _: [AnyObject], _: ExampleCollectionViewCell)

I didn't take  a closer look at the code but maybe it would be better suited to have the SKPhotoBrowser initializer arguments be instead?:

SKPhotoBrowser(_: UIIimage, _: [SKPhotoProtocol], _: ExampleCollectionViewCell)

Cheers!