### PR TITLE
activity indicator bugfixes

### DIFF
--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -77,7 +77,7 @@ public class SKZoomingScrollView: UIScrollView, UIScrollViewDelegate, SKDetectin
     
     public override func layoutSubviews() {
         tapView.frame = bounds
-        indicatorView.frame = frame 
+        indicatorView.frame = bounds
         
         super.layoutSubviews()
         


### PR DESCRIPTION
The activity indicator only worked on the first image when showing multiple images, because the activity indicator's frame was set incorrectly. This fixes that issue