### PR TITLE
add a delegate to notify when the user scroll to an index

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ browser.disableVerticalSwipe = true
 There's some trigger point you can handle using delegate. those are optional.
 - didShowPhotoAtIndex(index:Int) 
 - willDismissAtPageIndex(index:Int)
+- willShowActionSheet(photoIndex: Int)
 - didDismissAtPageIndex(index:Int)
 - didDismissActionSheetWithButtonIndex(buttonIndex: Int, photoIndex: Int)
 - removePhoto(browser: SKPhotoBrowser, index: Int, reload: (() -> Void))
+- viewForPhoto(browser: SKPhotoBrowser, index: Int) -> UIView?
 
 ```swift
 let browser = SKPhotoBrowser(originImage: originImage, photos: images, animatedFromView: cell)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ There's some trigger point you can handle using delegate. those are optional.
 - willShowActionSheet(photoIndex: Int)
 - didDismissAtPageIndex(index:Int)
 - didDismissActionSheetWithButtonIndex(buttonIndex: Int, photoIndex: Int)
+- didScrollToIndex(index: Int)
 - removePhoto(browser: SKPhotoBrowser, index: Int, reload: (() -> Void))
 - viewForPhoto(browser: SKPhotoBrowser, index: Int) -> UIView?
 

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -45,7 +45,14 @@ import UIKit
      - Parameter photoIndex: the index of the current photo
      */
     optional func didDismissActionSheetWithButtonIndex(buttonIndex: Int, photoIndex: Int)
-    
+
+    /**
+     Tells the delegate that the browser did scroll to index
+
+     - Parameter index: the index of the photo where the user had scroll
+     */
+    optional func didScrollToIndex(index: Int)
+
     /**
      Tells the delegate the user removed a photo, when implementing this call, be sure to call reload to finish the deletion process
      
@@ -1256,6 +1263,9 @@ public class SKPhotoBrowser: UIViewController, UIScrollViewDelegate {
     
     public func scrollViewDidEndDecelerating(scrollView: UIScrollView) {
         hideControlsAfterDelay()
+
+        let currentIndex = self.pagingScrollView.contentOffset.x / self.pagingScrollView.frame.size.width
+        self.delegate?.didScrollToIndex?(Int(currentIndex))
     }
     
     public func scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {


### PR DESCRIPTION
Firstly thanks so much for your library,
I just added a 'didScrollToIndex' delegate so when the user scroll to a page the delegate can be notify of it, it's useful when for example you have a gallery of picture and want to scroll it at the same time as the SKPhotoBrowser,
feel free to merge it if you liked it !