### PR TITLE
Skip loading image if already loaded

### DIFF
--- a/SKPhotoBrowser/SKPhoto.swift
+++ b/SKPhotoBrowser/SKPhoto.swift
@@ -69,8 +69,9 @@ public class SKPhoto: NSObject, SKPhotoProtocol {
     
     public func loadUnderlyingImageAndNotify() {
         
-        if underlyingImage != nil && photoURL == nil {
+        if underlyingImage != nil {
             loadUnderlyingImageComplete()
+            return
         }
         
         if photoURL != nil {


### PR DESCRIPTION
I noticed that the image was loaded every time it came into view even though it has already been loaded or fetched from cache. This should fix it.