### PR TITLE
Fixed logic of animated statement.

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -207,11 +207,11 @@ public class SKPhotoBrowser: UIViewController {
     public func dismissPhotoBrowser(animated animated: Bool, completion: (Void -> Void)? = nil) {
         prepareForClosePhotoBrowser()
 
-        if !animated {
+        if animated {
             modalTransitionStyle = .CrossDissolve
         }
         
-        dismissViewControllerAnimated(!animated) {
+        dismissViewControllerAnimated(animated) {
             completion?()
             self.delegate?.didDismissAtPageIndex?(self.currentPageIndex)
         }


### PR DESCRIPTION
The method dismissPhotoBrowser should only animate if the parameter animated is true.
dismissPhotoBrowser(animated: true)   // should animate
dismissPhotoBrowser(animated: false)   // should not animate
