### PR TITLE
add getCurrentPageIndex() in SKPhotoBrowser

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -360,6 +360,10 @@ public extension SKPhotoBrowser {
             present(activityViewController, animated: true, completion: nil)
         }
     }
+    
+    func getCurrentPageIndex() -> Int {
+        return currentPageIndex
+    }
 }
 
 


### PR DESCRIPTION
a public getter of `currentPageIndex` in `SKPhotoBrowser` would be helpful when library user customising the `SKPhotoBrowser` class
