### PR TITLE
Add @escaping to delegate method's reload closure parameter.

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowserDelegate.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserDelegate.swift
@@ -60,7 +60,7 @@ import Foundation
      - Parameter index: the index of the removed photo
      - Parameter reload: function that needs to be called after finishing syncing up
      */
-    @objc optional func removePhoto(_ browser: SKPhotoBrowser, index: Int, reload: (() -> Void))
+    @objc optional func removePhoto(_ browser: SKPhotoBrowser, index: Int, reload: @escaping (() -> Void))
     
     /**
      Asks the delegate for the view for a certain photo. Needed to detemine the animation when presenting/closing the browser.


### PR DESCRIPTION
Since the escaping/non-escaping behaviour of closure arguments was inverted in Swift 3, the compiler will no longer allow the closure passed to `removePhoto(_:index:reload:)` to be called after an asynchronous operation. The most obvious use of this, and the one I encountered, was displaying a confirmation alert before deleting an image.

Adding the `@escaping` attribute allows the same flexibility that was available before.