### PR TITLE
Update tests to run under Swift 3

### DIFF
--- a/SKPhotoBrowser.xcodeproj/project.pbxproj
+++ b/SKPhotoBrowser.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "Alexsander-Khitev.SKPhotoBrowserTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -484,7 +484,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "Alexsander-Khitev.SKPhotoBrowserTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};

--- a/SKPhotoBrowserTests/SKCacheTests.swift
+++ b/SKPhotoBrowserTests/SKCacheTests.swift
@@ -36,7 +36,7 @@ class SKCacheTests: XCTestCase {
     func testDefaultCacheImageForKey() {
         // given
         let cache = (self.cache.imageCache as? SKDefaultImageCache)!.cache
-        cache.setObject(self.image, forKey: self.key)
+        cache.setObject(self.image, forKey: self.key as AnyObject)
 
         // when
         let cachedImage = self.cache.imageForKey(self.key)
@@ -51,14 +51,14 @@ class SKCacheTests: XCTestCase {
 
         // then
         let cache = (self.cache.imageCache as? SKDefaultImageCache)!.cache
-        let cachedImage = cache.objectForKey(self.key) as? UIImage
+        let cachedImage = cache.object(forKey: self.key as AnyObject) as? UIImage
         XCTAssertNotNil(cachedImage)
     }
 
     func testDefaultCacheRemoveImageForKey() {
         // given
         let cache = (self.cache.imageCache as? SKDefaultImageCache)!.cache
-        cache.setObject(self.image, forKey: self.key)
+        cache.setObject(self.image, forKey: self.key as AnyObject)
 
         // when
         self.cache.removeImageForKey(self.key)

--- a/SKPhotoBrowserTests/SKPhotoBrowserTests.swift
+++ b/SKPhotoBrowserTests/SKPhotoBrowserTests.swift
@@ -44,7 +44,7 @@ class SKPhotoBrowserTests: XCTestCase {
 
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
A couple of missing casts and an updated method call, where previously the tests were compiling under Swift 2.3 and so couldn't import the main module as built under Swift 3.x.