### PR TITLE
Move the willDismiss delegate call closer to the dismissal

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -206,6 +206,7 @@ open class SKPhotoBrowser: UIViewController {
     
     open func dismissPhotoBrowser(animated: Bool, completion: ((Void) -> Void)? = nil) {
         prepareForClosePhotoBrowser()
+        delegate?.willDismissAtPageIndex?(currentPageIndex)
 
         if !animated {
             modalTransitionStyle = .crossDissolve
@@ -218,7 +219,6 @@ open class SKPhotoBrowser: UIViewController {
     }
 
     open func determineAndClose() {
-        delegate?.willDismissAtPageIndex?(currentPageIndex)
         animator.willDismiss(self)
     }
 }


### PR DESCRIPTION
I'm not 100% on this, but it does seem right.

I encountered a problem where the dismissal of the photo browser after deleting the last image does not call the delegate's `willDidmissAtPageIndex(_:)` method. The intention in this diff is to make sure that *all* dismissal paths will include a call to this delegate method.