### PR TITLE
Fix a fatal error when app's window is customized.

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -94,10 +94,13 @@ open class SKPhotoBrowser: UIViewController {
     }
     
     func setup() {
-        guard let window = UIApplication.shared.delegate?.window else {
+        if let window = UIApplication.shared.delegate?.window {
+            applicationWindow = window
+        }else if let window = UIApplication.shared.keyWindow {
+            applicationWindow = window
+        }else {
             return
         }
-        applicationWindow = window
         
         modalPresentationCapturesStatusBarAppearance = true
         modalPresentationStyle = .custom


### PR DESCRIPTION
Fix a fatal error course the applicationWindow property has not been init in setup when app's window is customized.