### PR TITLE
Always load from the URL even if a placeholder image exists

### DIFF
--- a/SKPhotoBrowser/SKPhoto.swift
+++ b/SKPhotoBrowser/SKPhoto.swift
@@ -68,12 +68,6 @@ public class SKPhoto: NSObject, SKPhotoProtocol {
     }
     
     public func loadUnderlyingImageAndNotify() {
-        
-        if underlyingImage != nil {
-            loadUnderlyingImageComplete()
-            return
-        }
-        
         if photoURL != nil {
             // Fetch Image
             let session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())


### PR DESCRIPTION
Currently, the image at the URL is never loaded if a placeholder image was passed in initially. We should always load from the URL if there is one.