### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath i
    let cell = collectionView.cellForItemAtIndexPath(indexPath) 
    let originImage = cell.exampleImageView.image // some image for baseImage 
 
-   let browser = SKPhotoBrowser(originImage: originImage, photos: images, animatedFromView: cell) 
+   let browser = SKPhotoBrowser(originImage: originImage ?? UIImage(), photos: images, animatedFromView: cell) 
    browser.initializePageIndex(indexPath.row)
    presentViewController(browser, animated: true, completion: {})
 }


### PR DESCRIPTION
`UIImageView`'s `image` property is a `UIImage?` and you'd need to unwrap it before passing to the init method (which takes a `UIImage`).
Many tend to trust Xcode and put `!` after `image`, thinking it can never be `nil` (speaking from experience). But it can be, if image isn't loaded into from the internet yet. 
Anyway, this little change makes the code in the readme compilable and helps avoid stupid mistakes.