### PR TITLE
fix: deleteButton frame does not update if screen has rotated

### DIFF
--- a/SKPhotoBrowser/SKButtons.swift
+++ b/SKPhotoBrowser/SKButtons.swift
@@ -42,6 +42,8 @@ class SKButton: UIButton {
         showFrame = newRect
         hideFrame = CGRect(x: margin, y: -20, width: size.width, height: size.height)
     }
+    
+    func updateFrame(_ frameSize: CGSize) { }
 }
 
 class SKCloseButton: SKButton {
@@ -76,5 +78,10 @@ class SKDeleteButton: SKButton {
         self.frame = newRect
         showFrame = newRect
         hideFrame = CGRect(x: SKMesurement.screenWidth - size.width, y: -20, width: size.width, height: size.height)
+    }
+    
+    override func updateFrame(_ newScreenSize: CGSize) {
+        showFrame = CGRect(x: newScreenSize.width - size.width, y: buttonTopOffset, width: size.width, height: size.height)
+        hideFrame = CGRect(x: newScreenSize.width - size.width, y: -20, width: size.width, height: size.height)
     }
 }

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -159,6 +159,11 @@ open class SKPhotoBrowser: UIViewController {
         }
     }
     
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        deleteButton.updateFrame(size)
+    }
+    
     // MARK: - Notification
     open func handleSKPhotoLoadingDidEndNotification(_ notification: Notification) {
         guard let photo = notification.object as? SKPhotoProtocol else {


### PR DESCRIPTION
I noticed the delete Button does not update frame if screen has rotated. I add override viewWillTransitionToSize() method and update correct deleteButton frame.

![2017-02-10 11 12 34](https://cloud.githubusercontent.com/assets/11748596/22811434/27dfb58e-ef82-11e6-819e-f4eb3e02bdbd.png)
![2017-02-10 11 12 07](https://cloud.githubusercontent.com/assets/11748596/22811444/2ff6a76e-ef82-11e6-84d6-a134efc1407e.png)