### PR TITLE
Swap and custom padding for delete and close buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,18 @@ SKPhotoBrowserOptions.displayToolbar = false                              // all
 SKPhotoBrowserOptions.displayCounterLabel = false                         // counter label will be hidden
 SKPhotoBrowserOptions.displayBackAndForwardButton = false                 // back / forward button will be hidden
 SKPhotoBrowserOptions.displayAction = false                               // action button will be hidden
-SKPhotoBrowserOptions.displayDeleteButton = true                          // delete button will be shown
 SKPhotoBrowserOptions.displayHorizontalScrollIndicator = false            // horizontal scroll bar will be hidden
 SKPhotoBrowserOptions.displayVerticalScrollIndicator = false              // vertical scroll bar will be hidden
 let browser = SKPhotoBrowser(originImage: originImage, photos: images, animatedFromView: cell)
 ```
 
 #### Colors
-You can customize text, icon and background colors via SKPhotoBrowserOptions
+You can customize text, icon and background colors via SKPhotoBrowserOptions or SKToolbarOptions
 ```swift
 SKPhotoBrowserOptions.backgroundColor = UIColor.whiteColor()               // browser view will be white
 SKPhotoBrowserOptions.textAndIconColor = UIColor.blackColor()              // text and icons will be black
-SKPhotoBrowserOptions.toolbarTextShadowColor = UIColor.clearColor()        // shadow of toolbar text will be removed
-SKPhotoBrowserOptions.toolbarFont = UIFont(name: "Futura", size: 16.0)     // font of toolbar will be 'Futura'
-SKPhotoBrowserOptions.captionFont = UIFont(name: "Helvetica", size: 18.0)  // font of toolbar will be 'Helvetica'
+SKToolbarOptions.textShadowColor = UIColor.clearColor()                    // shadow of toolbar text will be removed
+SKToolbarOptions.font = UIFont(name: "Futura", size: 16.0)                 // font of toolbar will be 'Futura'
 ```
 
 #### Images
@@ -142,6 +140,14 @@ SKPhotoBrowserOptions.imagePaddingY = 50                                   // im
 You can customize the visibility of the Statusbar in browser view via SKPhotoBrowserOptions
 ```swift
 SKPhotoBrowserOptions.displayStatusbar = false                             // status bar will be hidden
+```
+
+#### Close And Delete Buttons
+That how you can customize close and delete buttons
+```
+SKPhotoBrowserOptions.displayDeleteButton = true                           // delete button will be shown
+SKPhotoBrowserOptions.swapCloseAndDeleteButtons = true                     // now close button located on right side of screen and delete button is on left side
+SKPhotoBrowserOptions.closeAndDeleteButtonPadding = 20                     // set offset from top and from nearest screen edge of close button and delete button
 ```
 
 #### Custom Cache From Web URL

--- a/SKPhotoBrowser/SKButtons.swift
+++ b/SKPhotoBrowser/SKButtons.swift
@@ -22,8 +22,11 @@ class SKButton: UIButton {
         }
     }
     var size: CGSize = CGSize(width: 44, height: 44)
-    var margin: CGFloat = 5
-    var buttonTopOffset: CGFloat { return 5 }
+    var margin: CGFloat = SKPhotoBrowserOptions.closeAndDeleteButtonPadding
+    
+    var buttonTopOffset: CGFloat {
+        return SKPhotoBrowserOptions.closeAndDeleteButtonPadding
+    }
     
     func setup(_ imageName: String) {
         backgroundColor = .clear
@@ -44,8 +47,20 @@ class SKButton: UIButton {
     }
 }
 
-class SKCloseButton: SKButton {
-    let imageName = "btn_common_close_wh"
+class SKImageButton: SKButton {
+    
+    fileprivate var leftSidePositionMargin: CGFloat {
+        return super.margin
+    }
+    
+    fileprivate var rightSidePositionMargin: CGFloat {
+        return SKMesurement.screenWidth - super.margin - self.size.width
+    }
+    
+    fileprivate var imageName: String {
+        return ""
+    }
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -58,23 +73,30 @@ class SKCloseButton: SKButton {
     }
 }
 
-class SKDeleteButton: SKButton {
-    let imageName = "btn_common_delete_wh"
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
+class SKCloseButton: SKImageButton {
+    override var imageName: String { return "btn_common_close_wh" }
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setup(imageName)
-        showFrame = CGRect(x: SKMesurement.screenWidth - size.width, y: buttonTopOffset, width: size.width, height: size.height)
-        hideFrame = CGRect(x: SKMesurement.screenWidth - size.width, y: -20, width: size.width, height: size.height)
+    override var margin: CGFloat {
+        get {
+            return SKPhotoBrowserOptions.swapCloseAndDeleteButtons
+                ? rightSidePositionMargin
+                : leftSidePositionMargin
+        }
+        set {
+            super.margin = newValue
+        }
     }
-  
-    override func setFrameSize(_ size: CGSize) {
-        let newRect = CGRect(x: SKMesurement.screenWidth - size.width, y: buttonTopOffset, width: size.width, height: size.height)
-        self.frame = newRect
-        showFrame = newRect
-        hideFrame = CGRect(x: SKMesurement.screenWidth - size.width, y: -20, width: size.width, height: size.height)
+}
+
+class SKDeleteButton: SKImageButton {
+    override var imageName: String { return "btn_common_delete_wh" }
+    
+    
+    override var margin: CGFloat {
+        get { return SKPhotoBrowserOptions.swapCloseAndDeleteButtons
+            ? leftSidePositionMargin
+            : rightSidePositionMargin
+        }
+        set { super.margin = newValue }
     }
 }

--- a/SKPhotoBrowser/SKPhotoBrowserOptions.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserOptions.swift
@@ -31,6 +31,22 @@ public struct SKPhotoBrowserOptions {
     public static var enableSingleTapDismiss: Bool = false
     
     public static var backgroundColor: UIColor = .black
+    
+    public static var toolbarTextShadowColor: UIColor = .darkText
+    
+    
+    /// By default close button is on left side and delete button is on right.
+    ///
+    /// Set this property to **true** for swap they.
+    ///
+    /// Default: false
+    public static var swapCloseAndDeleteButtons = false
+    
+    
+    /// Offset from top and from nearest screen edge of close button and delete button.
+    ///
+    /// - Default: 5
+    public static var closeAndDeleteButtonPadding: CGFloat = 5
 }
 
 public struct SKCaptionOptions {
@@ -44,4 +60,5 @@ public struct SKCaptionOptions {
 public struct SKToolbarOptions {
     public static var textColor: UIColor = .white
     public static var font: UIFont = .systemFont(ofSize: 17.0)
+    public static var textShadowColor: UIColor = .black
 }

--- a/SKPhotoBrowser/SKToolbar.swift
+++ b/SKPhotoBrowser/SKToolbar.swift
@@ -109,7 +109,7 @@ private extension SKToolbar {
         toolCounterLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 95, height: 40))
         toolCounterLabel.textAlignment = .center
         toolCounterLabel.backgroundColor = .clear
-        toolCounterLabel.shadowColor = .black
+        toolCounterLabel.shadowColor = SKToolbarOptions.textShadowColor
         toolCounterLabel.shadowOffset = CGSize(width: 0.0, height: 1.0)
         toolCounterLabel.font = SKToolbarOptions.font
         toolCounterLabel.textColor = SKToolbarOptions.textColor


### PR DESCRIPTION
By default close button located on left side of screen. Now customers can move it to the right side (swap with delete button). Also padding of close and delete buttons can be customised using SKPhotoBrowserOptions. 