### PR TITLE
Replaced deprecated Pi constants

### DIFF
--- a/SKPhotoBrowser/extensions/UIImage+Rotation.swift
+++ b/SKPhotoBrowser/extensions/UIImage+Rotation.swift
@@ -49,15 +49,15 @@ extension UIImage {
         switch self.imageOrientation {
         case .down, .downMirrored:
             transform = transform.translatedBy(x: self.size.width, y: self.size.height)
-            transform = transform.rotated(by: CGFloat(M_PI))
+            transform = transform.rotated(by: CGFloat(Double.pi))
 
         case .left, .leftMirrored:
             transform = transform.translatedBy(x: self.size.width, y: 0)
-            transform = transform.rotated(by: CGFloat(M_PI_2))
+            transform = transform.rotated(by: CGFloat(Double.pi/2))
 
         case .right, .rightMirrored:
             transform = transform.translatedBy(x: 0, y: self.size.height)
-            transform = transform.rotated(by: CGFloat(-M_PI_2))
+            transform = transform.rotated(by: CGFloat(-Double.pi/2))
 
         default:
             break


### PR DESCRIPTION
The constants 'M_PI' and 'M_PI_2' are deprecated in Xcode 8.3.