### PR TITLE
Fixed UIWindow unwrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ Below is a table that shows which version of SKPhotoBrowser you should use for y
 | 2.3           | 2.0.4 - 3.1.4  |
 | 2.2           | <= 2.0.3        |
 
-##Installation
+## Installation
 
-####CocoaPods
+#### CocoaPods
 available on CocoaPods. Just add the following to your project Podfile:
 ```
 pod 'SKPhotoBrowser'
 use_frameworks!
 ```
 
-####Carthage
+#### Carthage
 To integrate into your Xcode project using Carthage, specify it in your Cartfile:
 
 ```ogdl
 github "suzuki-0000/SKPhotoBrowser"
 ```
 
-##Usage
+## Usage
 See the code snippet below for an example of how to implement, or see the example project.
 	
 from UIImages:

--- a/SKPhotoBrowser.xcodeproj/project.pbxproj
+++ b/SKPhotoBrowser.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		8CA6C6521CBE76E80054D3C2 /* SKLocalPhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA6C6511CBE76E80054D3C2 /* SKLocalPhoto.swift */; };
 		A64B89361CB04222000071B9 /* SKPhotoBrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B89351CB04222000071B9 /* SKPhotoBrowserTests.swift */; };
 		A64B89381CB04222000071B9 /* SKPhotoBrowser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8909B5301BC791280060A053 /* SKPhotoBrowser.framework */; };
+		D2265CCF1F799C75009256CC /* UIApplication+UIWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265CCE1F799C75009256CC /* UIApplication+UIWindow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +72,7 @@
 		A64B89331CB04222000071B9 /* SKPhotoBrowserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SKPhotoBrowserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A64B89351CB04222000071B9 /* SKPhotoBrowserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKPhotoBrowserTests.swift; sourceTree = "<group>"; };
 		A64B89371CB04222000071B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D2265CCE1F799C75009256CC /* UIApplication+UIWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+UIWindow.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 			children = (
 				210E53EC1C986D3A008DD5E3 /* UIView+Radius.swift */,
 				210E53EE1C986D57008DD5E3 /* UIImage+Rotation.swift */,
+				D2265CCE1F799C75009256CC /* UIApplication+UIWindow.swift */,
 			);
 			name = extensions;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 				89D0BA471D5994A8002A811B /* SKAnimator.swift in Sources */,
 				210E53ED1C986D3A008DD5E3 /* UIView+Radius.swift in Sources */,
 				8917B1B01D5A13DE000CE1C4 /* SKPhotoBrowserDelegate.swift in Sources */,
+				D2265CCF1F799C75009256CC /* UIApplication+UIWindow.swift in Sources */,
 				89D0BA491D59966B002A811B /* SKMesurement.swift in Sources */,
 				8909B5471BC791510060A053 /* SKPhoto.swift in Sources */,
 				8909B5461BC791510060A053 /* SKIndicatorView.swift in Sources */,

--- a/SKPhotoBrowser/SKAnimator.swift
+++ b/SKPhotoBrowser/SKAnimator.swift
@@ -37,10 +37,7 @@ class SKAnimator: NSObject, SKPhotoBrowserAnimatorDelegate {
     }
     
     func willPresent(_ browser: SKPhotoBrowser) {
-        guard let appWindow = UIApplication.shared.delegate?.window else {
-            return
-        }
-        guard let window = appWindow else {
+        guard let window = UIApplication.shared.preferredApplicationWindow else {
             return
         }
         guard let sender = browser.delegate?.viewForPhoto?(browser, index: browser.initialPageIndex) ?? senderViewForAnimation else {

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -99,13 +99,11 @@ open class SKPhotoBrowser: UIViewController {
     }
     
     func setup() {
-        if let window = UIApplication.shared.delegate?.window {
-            applicationWindow = window
-        } else if let window = UIApplication.shared.keyWindow {
-            applicationWindow = window
-        } else {
+        guard let window = UIApplication.shared.preferredApplicationWindow else {
             return
         }
+
+        applicationWindow = window
         
         modalPresentationCapturesStatusBarAppearance = true
         modalPresentationStyle = .custom

--- a/SKPhotoBrowser/UIApplication+UIWindow.swift
+++ b/SKPhotoBrowser/UIApplication+UIWindow.swift
@@ -1,0 +1,23 @@
+//
+//  UIApplication+UIWindow.swift
+//  SKPhotoBrowser
+//
+//  Created by Josef Dolezal on 25/09/2017.
+//  Copyright © 2017 suzuki_keishi. All rights reserved.
+//
+
+import Foundation
+
+internal extension UIApplication {
+    var preferredApplicationWindow: UIWindow? {
+        // Since delegate window is of type UIWindow??, we have to
+        // unwrap it twice to be sure the window is not nil
+        if let appWindow = UIApplication.shared.delegate?.window, let window = appWindow {
+            return window
+        } else if let window = UIApplication.shared.keyWindow {
+            return window
+        }
+
+        return nil
+    }
+}


### PR DESCRIPTION
Hey @suzuki-0000! First of all, thank you for amazing library and for all the hard work behind it!

This PR fixes crash on presenting `SKPhotoBrowser`. The crash appeared when `UIApplicationDelegate` has `window` property set to `nil`. The `if-let` statement did not unwrap the window correctly because of its type `UIWindow??` (damn optionals!).

Similar crash appeared on `SKPhotoBrowser` dismiss, where is missing the fallback to `UIApplication` key window.

I also updated the format of some README headings, since it was not rendered correctly.