### PR TITLE
Remove unused options

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowserOptions.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserOptions.swift
@@ -15,13 +15,11 @@ public struct SKPhotoBrowserOptions {
     public static var shareExtraCaption: String?
     public static var actionButtonTitles: [String]?
     
-    public static var displayToolbar: Bool = true
     public static var displayCounterLabel: Bool = true
     public static var displayBackAndForwardButton: Bool = true
     public static var disableVerticalSwipe: Bool = false
     
     public static var displayCloseButton: Bool = true
-    public static var displayDeleteButton: Bool = false
     
     public static var displayHorizontalScrollIndicator: Bool = true
     public static var displayVerticalScrollIndicator: Bool = true


### PR DESCRIPTION
I removed some unused options.
```
   public static var displayToolbar: Bool = true
   public static var displayDeleteButton: Bool = false
```
Those properties is unused and so confusing that I can not show delete button correctly.
Thanks for opening this useful framework.