### PR TITLE
Add SWIFT_VERSION to xcconfig

### DIFF
--- a/SKPhotoBrowser.podspec
+++ b/SKPhotoBrowser.podspec
@@ -1,14 +1,15 @@
 Pod::Spec.new do |s|
-  s.name         = "SKPhotoBrowser"
-  s.version      = "5.0.3"
-  s.summary      = "Simple PhotoBrowser/Viewer inspired by facebook, twitter photo browsers written by swift."
-  s.homepage     = "https://github.com/suzuki-0000/SKPhotoBrowser"
-  s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.author       = { "suzuki_keishi" => "keishi.1983@gmail.com" }
-  s.source       = { :git => "https://github.com/suzuki-0000/SKPhotoBrowser.git", :tag => s.version }
-  s.platform     = :ios, "8.0"
-  s.source_files = "SKPhotoBrowser/**/*.{h,swift}"
-  s.resources    = "SKPhotoBrowser/SKPhotoBrowser.bundle"
-  s.requires_arc = true
-  s.frameworks   = "UIKit"
+  s.name                = "SKPhotoBrowser"
+  s.version             = "5.0.3"
+  s.summary             = "Simple PhotoBrowser/Viewer inspired by facebook, twitter photo browsers written by swift."
+  s.homepage            = "https://github.com/suzuki-0000/SKPhotoBrowser"
+  s.license             = { :type => "MIT", :file => "LICENSE" }
+  s.author              = { "suzuki_keishi" => "keishi.1983@gmail.com" }
+  s.source              = { :git => "https://github.com/suzuki-0000/SKPhotoBrowser.git", :tag => s.version }
+  s.platform            = :ios, "8.0"
+  s.source_files        = "SKPhotoBrowser/**/*.{h,swift}"
+  s.resources           = "SKPhotoBrowser/SKPhotoBrowser.bundle"
+  s.requires_arc        = true
+  s.frameworks          = "UIKit"
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 end


### PR DESCRIPTION
This will add SWIFT_VERSION to pod target xcconfig. This is required because
Xcode complains when compiling app with the SKPhotoBrowser as a dependency.

```
The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.
```

This setting is also included in the podspec of other libraries that are Swift 4 compatible:

https://github.com/melvitax/DateHelper/blob/master/AFDateHelper.podspec
https://github.com/AlexLittlejohn/ALCameraViewController/blob/master/ALCameraViewController.podspec

This should also fixes #254