### PR TITLE
When disableVerticalSwipe is true the browser crashes on close

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -30,7 +30,7 @@ open class SKPhotoBrowser: UIViewController {
 
     // actions
     fileprivate var activityViewController: UIActivityViewController!
-    fileprivate var panGesture: UIPanGestureRecognizer!
+    fileprivate var panGesture: UIPanGestureRecognizer?
 
     // for status check property
     fileprivate var isEndAnimationByToolBar: Bool = true
@@ -197,7 +197,9 @@ open class SKPhotoBrowser: UIViewController {
     
     open func prepareForClosePhotoBrowser() {
         cancelControlHiding()
-        view.removeGestureRecognizer(panGesture)
+        if let panGesture = panGesture {
+            view.removeGestureRecognizer(panGesture)
+        }
         NSObject.cancelPreviousPerformRequests(withTarget: self)
     }
     
@@ -540,9 +542,12 @@ private extension SKPhotoBrowser {
             return
         }
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(SKPhotoBrowser.panGestureRecognized(_:)))
-        panGesture.minimumNumberOfTouches = 1
-        panGesture.maximumNumberOfTouches = 1
-        view.addGestureRecognizer(panGesture)
+        panGesture?.minimumNumberOfTouches = 1
+        panGesture?.maximumNumberOfTouches = 1
+
+        if let panGesture = panGesture {
+            view.addGestureRecognizer(panGesture)
+        }
     }
     
     func configureActionView() {


### PR DESCRIPTION
- If the user sets `SKPhotoBrowserOptions.disableVerticalSwipe` to true we are not creating a `panGesture` within `configureGestureControl` function but we are unconditionally trying to remove the `panGesture` from the view on `prepareForClosePhotoBrowser`.
- Since the panGesture is setup as a force unwrap the applications crashes
 