### PR TITLE
I want to hide SKPagingScrollView's horizontal indicator

### DIFF
--- a/SKPhotoBrowser/SKPagingScrollView.swift
+++ b/SKPhotoBrowser/SKPagingScrollView.swift
@@ -32,7 +32,7 @@ class SKPagingScrollView: UIScrollView {
         self.browser = browser
 
         isPagingEnabled = true
-        showsHorizontalScrollIndicator = true
+        showsHorizontalScrollIndicator = SKPhotoBrowserOptions.displayPagingHorizontalScrollIndicator
         showsVerticalScrollIndicator = true
 
         updateFrame(bounds, currentPageIndex: browser.currentPageIndex)

--- a/SKPhotoBrowser/SKPhotoBrowserOptions.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserOptions.swift
@@ -22,6 +22,7 @@ public struct SKPhotoBrowserOptions {
 
     public static var displayHorizontalScrollIndicator: Bool = true
     public static var displayVerticalScrollIndicator: Bool = true
+    public static var displayPagingHorizontalScrollIndicator: Bool = true
     
     public static var bounceAnimation: Bool = false
     public static var enableZoomBlackArea: Bool = true


### PR DESCRIPTION

## What is this PR?
Current version, we can't hide scroll horizontal indicator in SKPagingScrollView.
So I add parameter for changing it to SKPhotoBrowserOptions.
We can change visibility of SKPagingScrollView's horizontal indicator. (default is true)

## Why do we need this PR?
I can't see the horizontal indicator in example project.
But I see the horizontal indicator in the case of the following code.

```FromWebViewController.swift
SKPhotoBrowserOptions.backgroundColor = UIColor.white
``` 

## Other
I feel that parameter variable name is not good.
I want to rename if you have a nice name idea.
