### PR TITLE
Add method to remove all images for SKCache

### DIFF
--- a/SKPhotoBrowser/SKCache.swift
+++ b/SKPhotoBrowser/SKCache.swift
@@ -39,6 +39,14 @@ open class SKCache {
         
         cache.removeImageForKey(key)
     }
+    
+    open func removeAllImages() {
+        guard let cache = imageCache as? SKImageCacheable else {
+            return
+        }
+        
+        cache.removeAllImages()
+    }
 
     open func imageForRequest(_ request: URLRequest) -> UIImage? {
         guard let cache = imageCache as? SKRequestResponseCacheable else {
@@ -77,5 +85,9 @@ class SKDefaultImageCache: SKImageCacheable {
 
     func removeImageForKey(_ key: String) {
         cache.removeObject(forKey: key as AnyObject)
+    }
+    
+    func removeAllImages() {
+        cache.removeAllObjects()
     }
 }

--- a/SKPhotoBrowser/SKCacheable.swift
+++ b/SKPhotoBrowser/SKCacheable.swift
@@ -13,6 +13,7 @@ public protocol SKImageCacheable: SKCacheable {
     func imageForKey(_ key: String) -> UIImage?
     func setImage(_ image: UIImage, forKey key: String)
     func removeImageForKey(_ key: String)
+    func removeAllImages()
 }
 
 public protocol SKRequestResponseCacheable: SKCacheable {

--- a/SKPhotoBrowserTests/SKCacheTests.swift
+++ b/SKPhotoBrowserTests/SKCacheTests.swift
@@ -66,4 +66,23 @@ class SKCacheTests: XCTestCase {
         let cachedImage = self.cache.imageForKey(self.key)
         XCTAssertNil(cachedImage)
     }
+    
+    func testDefaultCacheRemoveAllImages() {
+        // given
+        let cache = (self.cache.imageCache as? SKDefaultImageCache)!.cache
+        cache.setObject(self.image, forKey: self.key as AnyObject)
+        
+        let anotherImage = UIImage()
+        let anotherKey = "another_test_image"
+        cache.setObject(anotherImage, forKey: anotherKey as AnyObject)
+        
+        // when
+        self.cache.removeAllImages()
+        
+        // then
+        let cachedImage = self.cache.imageForKey(self.key)
+        let anotherCachedImage = self.cache.imageForKey(anotherKey)
+        XCTAssertNil(cachedImage)
+        XCTAssertNil(anotherCachedImage)
+    }
 }


### PR DESCRIPTION
This method allows to clear the default cache or every entity that implements the SKCacheable protocol