### PR TITLE
Add possibility to provide custom request parameters

### DIFF
--- a/SKPhotoBrowser/SKPhoto.swift
+++ b/SKPhotoBrowser/SKPhoto.swift
@@ -70,7 +70,7 @@ open class SKPhoto: NSObject, SKPhotoProtocol {
         guard photoURL != nil, let URL = URL(string: photoURL) else { return }
         
         // Fetch Image
-        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let session = URLSession(configuration: SKPhotoBrowserOptions.sessionConfiguration)
             var task: URLSessionTask?
             task = session.dataTask(with: URL, completionHandler: { [weak self] (data, response, error) in
                 guard let `self` = self else { return }

--- a/SKPhotoBrowser/SKPhotoBrowserOptions.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserOptions.swift
@@ -44,6 +44,9 @@ public struct SKPhotoBrowserOptions {
     /// and the minScale is 1.0, the maxScale is 2.5
     /// Default: false
     public static var longPhotoWidthMatchScreen: Bool = false
+
+    /// Provide custom session configuration (eg. for headers, etc.)
+    public static var sessionConfiguration: URLSessionConfiguration = .default
 }
 
 public struct SKButtonOptions {


### PR DESCRIPTION
This pull request is reaction to Issue #161 - How to set Header. It allows users to provide custom request headers (for authentication for example) and other parameters by providing their own URLSessionConfiguration, that is used for image data requests.