### PR TITLE
Fix: Unable to set delete and close button images without setting size.

### DIFF
--- a/SKPhotoBrowser/SKActionView.swift
+++ b/SKPhotoBrowser/SKActionView.swift
@@ -95,11 +95,13 @@ extension SKActionView {
             addSubview(closeButton)
         }
 
-        guard let size = size else { return }
-        closeButton.setFrameSize(size)
+        if let size = size {
+            closeButton.setFrameSize(size)
+        }
         
-        guard let image = image else { return }
-        closeButton.setImage(image, for: UIControlState())
+        if let image = image {
+            closeButton.setImage(image, for: UIControlState())
+        }
     }
     
     func configureDeleteButton(image: UIImage? = nil, size: CGSize? = nil) {
@@ -109,11 +111,13 @@ extension SKActionView {
             deleteButton.isHidden = !SKPhotoBrowserOptions.displayDeleteButton
             addSubview(deleteButton)
         }
-
-        guard let size = size else { return }
-        deleteButton.setFrameSize(size)
         
-        guard let image = image else { return }
-        deleteButton.setImage(image, for: UIControlState())
+        if let size = size {
+            deleteButton.setFrameSize(size)
+        }
+        
+        if let image = image {
+            deleteButton.setImage(image, for: UIControlState())
+        }
     }
 }


### PR DESCRIPTION
The way the `guard let` statements are currently used, we can't omit the size parameter when calling
`updateCloseButton(_ image: UIImage, size: CGSize? = nil)`  and `updateDeleteButton(_ image: UIImage, size: CGSize? = nil)` methods via an instance of SKPhotoBrowser even though the size parameter is optional. 

The above methods delegate to calling `actionView.updateCloseButton(image:, size:)` and 
`actionView.updateDeleteButton(image:, size:)` internally which also delgate to calling `configureCloseButton(image:, size:)` and `configureDeleteButton(image:, size:)` which is where the parameters are used with a `guard let` check.

This PR fixes this issue.