### PR TITLE
fix unreleased views in uiwindow for non-dismiss animation case

### DIFF
--- a/SKPhotoBrowser.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SKPhotoBrowser.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SKPhotoBrowser/SKAnimator.swift
+++ b/SKPhotoBrowser/SKAnimator.swift
@@ -84,7 +84,10 @@ class SKAnimator: NSObject, SKPhotoBrowserAnimatorDelegate {
             let scrollView = browser.pageDisplayedAtIndex(browser.currentPageIndex) else {
                 
             senderViewForAnimation?.isHidden = false
-            browser.dismissPhotoBrowser(animated: false)
+            browser.dismissPhotoBrowser(animated: false) {
+                self.resizableImageView?.removeFromSuperview()
+                self.backgroundView.removeFromSuperview()
+            }
             return
         }
 


### PR DESCRIPTION
if we present skbrowser from animated view for a 'single photo' but didn't implement the optional delegate method: 
`@objc optional func viewForPhoto(_ browser: SKPhotoBrowser, index: Int) -> UIView?`

The resizableImageview and backgroundView  should also be removed from UIWindow 

Optional way is to make the delegation method compulsory