### PR TITLE
Set the backround view's background color from settings

### DIFF
--- a/SKPhotoBrowser/SKAnimator.swift
+++ b/SKPhotoBrowser/SKAnimator.swift
@@ -22,7 +22,7 @@ class SKAnimator: NSObject, SKPhotoBrowserAnimatorDelegate {
         guard let window = UIApplication.shared.preferredApplicationWindow else { fatalError() }
         
         let backgroundView = UIView(frame: window.frame)
-        backgroundView.backgroundColor = .black
+        backgroundView.backgroundColor = SKPhotoBrowserOptions.backgroundColor
         backgroundView.alpha = 0.0
         return backgroundView
     }()


### PR DESCRIPTION
If the user decides to use color different than black the result is an awkward flash from black color to the selected from settings color. 
If the user doesn't set this property the black color is the default. So I can't find a case this solution breaks something. 