### PR TITLE
use the size of the window instead of UIScreen to support SplitScreen

### DIFF
--- a/SKPhotoBrowser/SKCaptionView.swift
+++ b/SKPhotoBrowser/SKCaptionView.swift
@@ -22,8 +22,7 @@ open class SKCaptionView: UIView {
     }
     
     public convenience init(photo: SKPhotoProtocol) {
-        let screenBound = UIScreen.main.bounds
-        self.init(frame: CGRect(x: 0, y: 0, width: screenBound.size.width, height: screenBound.size.height))
+        self.init(frame: CGRect(x: 0, y: 0, width: SKMesurement.screenWidth, height: SKMesurement.screenHeight))
         self.photo = photo
         setup()
     }

--- a/SKPhotoBrowser/SKMesurement.swift
+++ b/SKPhotoBrowser/SKMesurement.swift
@@ -16,10 +16,10 @@ struct SKMesurement {
         return UIApplication.shared.statusBarFrame.height
     }
     static var screenHeight: CGFloat {
-        return UIScreen.main.bounds.height
+        return UIApplication.shared.preferredApplicationWindow?.bounds.height ?? UIScreen.main.bounds.height
     }
     static var screenWidth: CGFloat {
-        return UIScreen.main.bounds.width
+        return UIApplication.shared.preferredApplicationWindow?.bounds.width ?? UIScreen.main.bounds.width
     }
     static var screenScale: CGFloat {
         return UIScreen.main.scale

--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -124,9 +124,9 @@ open class SKZoomingScrollView: UIScrollView {
         var minScale: CGFloat = min(xScale, yScale)
         var maxScale: CGFloat = 1.0
         
-        let scale = max(UIScreen.main.scale, 2.0)
-        let deviceScreenWidth = UIScreen.main.bounds.width * scale // width in pixels. scale needs to remove if to use the old algorithm
-        let deviceScreenHeight = UIScreen.main.bounds.height * scale // height in pixels. scale needs to remove if to use the old algorithm
+        let scale = max(SKMesurement.screenScale, 2.0)
+        let deviceScreenWidth = SKMesurement.screenWidth * scale // width in pixels. scale needs to remove if to use the old algorithm
+        let deviceScreenHeight = SKMesurement.screenHeight * scale // height in pixels. scale needs to remove if to use the old algorithm
         
         if SKPhotoBrowserOptions.longPhotoWidthMatchScreen && imageView.frame.height >= imageView.frame.width {
             minScale = 1.0
@@ -329,8 +329,8 @@ private extension SKZoomingScrollView {
     func zoomRectForScrollViewWith(_ scale: CGFloat, touchPoint: CGPoint) -> CGRect {
         let w = frame.size.width / scale
         let h = frame.size.height / scale
-        let x = touchPoint.x - (h / max(UIScreen.main.scale, 2.0))
-        let y = touchPoint.y - (w / max(UIScreen.main.scale, 2.0))
+        let x = touchPoint.x - (h / max(SKMesurement.screenScale, 2.0))
+        let y = touchPoint.y - (w / max(SKMesurement.screenScale, 2.0))
         
         return CGRect(x: x, y: y, width: w, height: h)
     }


### PR DESCRIPTION
In order to support SplitScreen mode on iPad we need to use the size of the current window instead of the whole screen otherwise the animation when showing the photo in a smaller window size is broken