### PR TITLE
loop call SKPhotoBrowserDelegate.controlsVisibilityToggled function

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -587,7 +587,7 @@ private extension SKPhotoBrowser {
         // action view animation
         actionView.animate(hidden: hidden)
         
-        if !permanent {
+        if !hidden && !permanent {
             hideControlsAfterDelay()
         }
         setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
fix loop call  SKPhotoBrowserDelegate.controlsVisibilityToggled(_ browser: SKPhotoBrowser, hidden: Bool)
