### PR TITLE
Support for iPhoneXS, XSMax and XR

### DIFF
--- a/SKPhotoBrowser/SKMesurement.swift
+++ b/SKPhotoBrowser/SKMesurement.swift
@@ -28,7 +28,8 @@ struct SKMesurement {
         return screenWidth / screenHeight
     }
     static var isPhoneX: Bool {
-        if isPhone && UIScreen.main.nativeBounds.height == 2436 {
+        let iPhoneXHeights: [CGFloat] = [2436, 2688, 1792]
+        if isPhone, iPhoneXHeights.contains(UIScreen.main.nativeBounds.height) {
            return true
         }
         return false


### PR DESCRIPTION
The detection of the iPhoneX was based on a unique height.
I've added heights of the XS, XSMax and XR as well.