### PR TITLE
fix adding of the activity item from the input activity item provider

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -244,7 +244,7 @@ open class SKPhotoBrowser: UIViewController {
         }
         
         if let activityItemProvider = activityItemProvider {
-            activityItems.append(activityItemProvider)
+            activityItems.append(activityItemProvider.item as AnyObject)
         }
         
         activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)


### PR DESCRIPTION
Custom UIActivityItemProvider shouldn't itself be added into the browser's [UIActivityItem]. This commit fixes it by instead adding the UIActivityItemProvider.item to the browser's [UIActivityItem]. This will make custom UIActivityItemProvider work again.