### PR TITLE
Make tool action button public

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -17,6 +17,10 @@ open class SKPhotoBrowser: UIViewController {
     open var initPageIndex: Int = 0
     open var activityItemProvider: UIActivityItemProvider?
     open var photos: [SKPhotoProtocol] = []
+
+    public var toolActionButton: UIBarButtonItem {
+        return toolbar.toolActionButton
+    }
     
     internal lazy var pagingScrollView: SKPagingScrollView = SKPagingScrollView(frame: self.view.frame, browser: self)
     


### PR DESCRIPTION
The `toolbar.toolActionButton` is necessary for overriding the `popupShare(includeCaption: Bool = true)` in the `SKPhotoBroswer`.

i.e.

```swift
override func popupShare(includeCaption: Bool = true) {
        let photo = photos[currentPageIndex]

        let underlyingData = ...

        var activityItems: [AnyObject] = [underlyingData]
        if photo.caption != nil && includeCaption {
            if let shareExtraCaption = SKPhotoBrowserOptions.shareExtraCaption {
                let caption = photo.caption ?? "" + shareExtraCaption
                activityItems.append(caption as AnyObject)
            } else {
                activityItems.append(photo.caption as AnyObject)
            }
        }

        if let activityItemProvider = activityItemProvider {
            activityItems.append(activityItemProvider)
        }

        activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
        activityViewController.completionWithItemsHandler = { (activity, success, items, error) in
            self.hideControlsAfterDelay()
            self.activityViewController = nil
        }
        if UI_USER_INTERFACE_IDIOM() == .phone {
            present(activityViewController, animated: true, completion: nil)
        } else {
            activityViewController.modalPresentationStyle = .popover
            let popover: UIPopoverPresentationController! = activityViewController.popoverPresentationController
            popover.barButtonItem = toolActionButton
            present(activityViewController, animated: true, completion: nil)
        }
    }
```