### PR TITLE
fix: Add the [swift_version] attribute to podspec as a flutter plugin

### DIFF
--- a/SKPhotoBrowser.podspec
+++ b/SKPhotoBrowser.podspec
@@ -11,5 +11,7 @@ Pod::Spec.new do |s|
   s.resources           = "SKPhotoBrowser/SKPhotoBrowser.bundle"
   s.requires_arc        = true
   s.frameworks          = "UIKit"
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
+  s.swift_version = "5.0"
+  s.swift_versions = ['4.0', '4.2', '5.0']
 end


### PR DESCRIPTION
fix: Add the [swift_version] attribute to podspec as a flutter plugin