### PR TITLE
fix strong self reference

### DIFF
--- a/SKPhotoBrowser/SKPhoto.swift
+++ b/SKPhotoBrowser/SKPhoto.swift
@@ -73,7 +73,7 @@ open class SKPhoto: NSObject, SKPhotoProtocol {
         let session = URLSession(configuration: SKPhotoBrowserOptions.sessionConfiguration)
             var task: URLSessionTask?
             task = session.dataTask(with: URL, completionHandler: { [weak self] (data, response, error) in
-                guard let `self` = self else { return }
+                guard let self = self else { return }
                 defer { session.finishTasksAndInvalidate() }
 
                 guard error == nil else {


### PR DESCRIPTION
@suzuki-0000 Hi, 
When we refer self from a weak to strong, we often had used `` `self` ``  be surrounded by backticks.
However this is compiler bug, it has been resolved in Swift 4.2 by `guard` be able to capture `self` as it same name.

https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md