### PR TITLE
Swift Package Manager support. Xcode 12 update.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.0
+//
+//  Package.swift
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "SKPhotoBrowser",
+    platforms: [
+        .iOS(.v9)
+    ],
+    products: [
+        .library(
+            name: "SKPhotoBrowser",
+            targets: ["SKPhotoBrowser"])
+    ],
+    targets: [
+        .target(
+            name: "SKPhotoBrowser",
+            path: "SKPhotoBrowser")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Simple PhotoBrowser/Viewer inspired by facebook, twitter photo browsers written 
 | ![sample](Screenshots/example01.gif) | ![sample](Screenshots/example02.gif) |
 
 ## Requirements
-- iOS 8.0+
+- iOS 9.0+
 - Swift 2.0+
 - ARC
 
@@ -66,6 +66,10 @@ To integrate into your Xcode project using Carthage, specify it in your Cartfile
 ```ogdl
 github "suzuki-0000/SKPhotoBrowser"
 ```
+
+#### Swift Package Manager
+Available in Swift Package Manager. Use the repository URL in Xcode
+<em>File -> Swift Packages -> Add Package Dependency...</em>
 
 ## Usage
 See the code snippet below for an example of how to implement, or see the example project.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ github "suzuki-0000/SKPhotoBrowser"
 
 #### Swift Package Manager
 Available in Swift Package Manager. Use the repository URL in Xcode
-<em>File -> Swift Packages -> Add Package Dependency...</em>
+*File -> Swift Packages -> Add Package Dependency...*
 
 ## Usage
 See the code snippet below for an example of how to implement, or see the example project.

--- a/SKPhotoBrowser.xcodeproj/project.pbxproj
+++ b/SKPhotoBrowser.xcodeproj/project.pbxproj
@@ -224,12 +224,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = suzuki_keishi;
 				TargetAttributes = {
 					8909B52F1BC791280060A053 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1200;
 					};
 					A64B89321CB04222000071B9 = {
 						CreatedOnToolsVersion = 7.3;
@@ -239,10 +239,11 @@
 			};
 			buildConfigurationList = 8909B52A1BC791280060A053 /* Build configuration list for PBXProject "SKPhotoBrowser" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 8909B5261BC791280060A053;
 			productRefGroup = 8909B5311BC791280060A053 /* Products */;
@@ -361,6 +362,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -419,6 +421,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -460,14 +463,14 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SKPhotoBrowser/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keishi.suzuki.SKPhotoBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -482,13 +485,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SKPhotoBrowser/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keishi.suzuki.SKPhotoBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SKPhotoBrowser.xcodeproj/xcshareddata/xcschemes/SKPhotoBrowser.xcscheme
+++ b/SKPhotoBrowser.xcodeproj/xcshareddata/xcschemes/SKPhotoBrowser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:SKPhotoBrowser.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SKPhotoBrowser/SKButtons.swift
+++ b/SKPhotoBrowser/SKButtons.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 suzuki_keishi. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 // helpers which often used
 private let bundle = Bundle(for: SKPhotoBrowser.self)

--- a/SKPhotoBrowser/SKPagingScrollView.swift
+++ b/SKPhotoBrowser/SKPagingScrollView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 suzuki_keishi. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 class SKPagingScrollView: UIScrollView {
     fileprivate let pageIndexTagOffset: Int = 1000

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -88,10 +88,6 @@ open class SKPhotoBrowser: UIViewController {
         animator.senderOriginImage = photos[currentPageIndex].underlyingImage
         animator.senderViewForAnimation = photos[currentPageIndex] as? UIView
     }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
     
     func setup() {
         modalPresentationCapturesStatusBarAppearance = true

--- a/SKPhotoBrowser/SKPhotoBrowserDelegate.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 suzuki_keishi. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 @objc public protocol SKPhotoBrowserDelegate {
     

--- a/SKPhotoBrowser/SKToolbar.swift
+++ b/SKPhotoBrowser/SKToolbar.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017年 suzuki_keishi. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 // helpers which often used
 private let bundle = Bundle(for: SKPhotoBrowser.self)

--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -120,7 +120,7 @@ open class SKZoomingScrollView: UIScrollView {
         
         let xScale = boundsSize.width / imageSize.width
         let yScale = boundsSize.height / imageSize.height
-        var minScale: CGFloat = min(xScale.isNormal ? xScale : 1.0 , yScale.isNormal ? yScale : 1.0)
+        var minScale: CGFloat = min(xScale.isNormal ? xScale : 1.0, yScale.isNormal ? yScale : 1.0)
         var maxScale: CGFloat = 1.0
         
         let scale = max(SKMesurement.screenScale, 2.0)

--- a/SKPhotoBrowser/UIApplication+UIWindow.swift
+++ b/SKPhotoBrowser/UIApplication+UIWindow.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 suzuki_keishi. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 internal extension UIApplication {
     var preferredApplicationWindow: UIWindow? {


### PR DESCRIPTION
Added a simple manifest file to support Swift Package Manager.
Along with that resolved warnings that were displayed in Xcode 12. Unfortunately, it included increase of deployment target to 9.0.