### PR TITLE
Fixed image loading from SKPhotoBrowser.bundle for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 //
 //  Package.swift
 //
@@ -18,6 +18,11 @@ let package = Package(
     targets: [
         .target(
             name: "SKPhotoBrowser",
-            path: "SKPhotoBrowser")
+            path: "SKPhotoBrowser",
+            exclude: ["Info.plist"],
+            resources: [
+                .copy("SKPhotoBrowser.bundle")
+            ]
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -13,13 +13,19 @@ let package = Package(
     products: [
         .library(
             name: "SKPhotoBrowser",
-            targets: ["SKPhotoBrowser"])
+            targets: ["UIImageAnimatedGIF", "SKPhotoBrowser"])
     ],
     targets: [
         .target(
+            name: "UIImageAnimatedGIF",
+            path: "SKPhotoBrowser/extensions",
+            exclude: ["UIApplication+UIWindow.swift", "UIImage+Rotation.swift", "UIView+Radius.swift"]
+        ),
+        .target(
             name: "SKPhotoBrowser",
+            dependencies: ["UIImageAnimatedGIF"],
             path: "SKPhotoBrowser",
-            exclude: ["Info.plist"],
+            exclude: ["Info.plist", "extensions/UIImage+animatedGIF.h", "extensions/UIImage+animatedGIF.m"],
             resources: [
                 .copy("SKPhotoBrowser.bundle")
             ]

--- a/SKPhotoBrowser/SKButtons.swift
+++ b/SKPhotoBrowser/SKButtons.swift
@@ -9,7 +9,13 @@
 import UIKit
 
 // helpers which often used
-private let bundle = Bundle(for: SKPhotoBrowser.self)
+#if SWIFT_PACKAGE
+  private let bundle = Bundle.module
+#else
+  private let bundle = Bundle(for: SKPhotoBrowser.self)
+#endif
+
+private let imagesBundle = Bundle(url: bundle.url(forResource: "SKPhotoBrowser", withExtension: "bundle")!)!
 
 class SKButton: UIButton {
     internal var showFrame: CGRect!
@@ -32,8 +38,8 @@ class SKButton: UIButton {
         imageEdgeInsets = insets
         translatesAutoresizingMaskIntoConstraints = true
         autoresizingMask = [.flexibleBottomMargin, .flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin]
-        
-        let image = UIImage(named: "SKPhotoBrowser.bundle/images/\(imageName)", in: bundle, compatibleWith: nil) ?? UIImage()
+
+        let image = UIImage(named: "images/\(imageName)", in: imagesBundle, compatibleWith: nil) ?? UIImage()
         setImage(image, for: .normal)
     }
   


### PR DESCRIPTION
Buttons like delete button or close button fails to load images when using Swift Package Manager. This pull request attempts to fix it.

Bundling resources for SPM only available from Swift tools version 5.3: https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package