### PR TITLE
Fix the problem that the Arabic share button cannot be clicked.

### DIFF
--- a/SKPhotoBrowser/SKToolbar.swift
+++ b/SKPhotoBrowser/SKToolbar.swift
@@ -33,7 +33,7 @@ class SKToolbar: UIToolbar {
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if let view = super.hitTest(point, with: event) {
-            if SKMesurement.screenWidth - point.x < 50 { // FIXME: not good idea
+            if point.x < 50 || SKMesurement.screenWidth - point.x < 50 { // FIXME: not good idea
                 return view
             }
         }


### PR DESCRIPTION
If the Arabic share button is on the left, it will cause the button to be unclickable. I hope to release a version as soon as possible, and now I will overwrite the modified code every time I execute `pod install`.