### PR TITLE
feat: image protection from taking screen shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ SKPhotoBrowserOptions.swapCloseAndDeleteButtons = true                     // no
 SKPhotoBrowserOptions.closeAndDeleteButtonPadding = 20                     // set offset from top and from nearest screen edge of close button and delete button
 ```
 
+#### Screenshot Protection
+You can protect your image from taking screenshot via SKPhotoBrowserOptions
+Only working on the device, not on simulator
+```swift
+SKPhotoBrowserOptions.protectScreenshot = true                             // image will be hidden after taking screenshot
+```
+
 #### Custom Cache From Web URL
 You can use SKCacheable protocol if others are adaptable. (SKImageCacheable or SKRequestResponseCacheable)
 

--- a/SKPhotoBrowser.xcodeproj/project.pbxproj
+++ b/SKPhotoBrowser.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		9CF727E1285208180043487A /* UIImage+BundledImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF727E0285208180043487A /* UIImage+BundledImage.swift */; };
 		A64B89361CB04222000071B9 /* SKPhotoBrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64B89351CB04222000071B9 /* SKPhotoBrowserTests.swift */; };
 		A64B89381CB04222000071B9 /* SKPhotoBrowser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8909B5301BC791280060A053 /* SKPhotoBrowser.framework */; };
+		D6690B1E2A8F580B00AA18EA /* UIView+ScreenshotProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6690B1D2A8F580B00AA18EA /* UIView+ScreenshotProtection.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +84,7 @@
 		A64B89331CB04222000071B9 /* SKPhotoBrowserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SKPhotoBrowserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A64B89351CB04222000071B9 /* SKPhotoBrowserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKPhotoBrowserTests.swift; sourceTree = "<group>"; };
 		A64B89371CB04222000071B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D6690B1D2A8F580B00AA18EA /* UIView+ScreenshotProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ScreenshotProtection.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +162,7 @@
 				9CF727E0285208180043487A /* UIImage+BundledImage.swift */,
 				9521CC61232F677900446D11 /* UIImage+Rotation.swift */,
 				9521CC62232F677900446D11 /* UIView+Radius.swift */,
+				D6690B1D2A8F580B00AA18EA /* UIView+ScreenshotProtection.swift */,
 			);
 			path = extensions;
 			sourceTree = "<group>";
@@ -333,6 +336,7 @@
 				8917B1B41D5A14B0000CE1C4 /* SKButtons.swift in Sources */,
 				89C24A821D657AD1005F09A9 /* SKPhotoBrowserOptions.swift in Sources */,
 				9CF727E1285208180043487A /* UIImage+BundledImage.swift in Sources */,
+				D6690B1E2A8F580B00AA18EA /* UIView+ScreenshotProtection.swift in Sources */,
 				26C97AD51D0EB6870039F6CB /* SKCache.swift in Sources */,
 				8909B5431BC791510060A053 /* SKCaptionView.swift in Sources */,
 				8909B5491BC791510060A053 /* SKPhotoBrowser.swift in Sources */,

--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -553,6 +553,10 @@ private extension SKPhotoBrowser {
     func configurePagingScrollView() {
         pagingScrollView.delegate = self
         view.addSubview(pagingScrollView)
+        
+        if SKPhotoBrowserOptions.protectScreenshot {
+            paginationView.protectScreenshot()
+        }
     }
 
     func configureGestureControl() {

--- a/SKPhotoBrowser/SKPhotoBrowserOptions.swift
+++ b/SKPhotoBrowser/SKPhotoBrowserOptions.swift
@@ -47,6 +47,10 @@ public struct SKPhotoBrowserOptions {
 
     /// Provide custom session configuration (eg. for headers, etc.)
     public static var sessionConfiguration: URLSessionConfiguration = .default
+    
+    /// if this value is true, when you take a screenshot, the image will be hidden
+    /// only working on a device, not on simulator
+    public static var protectScreenshot: Bool = false
 }
 
 public struct SKButtonOptions {

--- a/SKPhotoBrowser/extensions/UIView+ScreenshotProtection.swift
+++ b/SKPhotoBrowser/extensions/UIView+ScreenshotProtection.swift
@@ -1,0 +1,24 @@
+//
+//  UIView+ScreenshotProtection.swift
+//  SKPhotoBrowser
+//
+//  Created by  JuyeonYu on 2023/08/18.
+//  Copyright © 2023 suzuki_keishi. All rights reserved.
+//
+
+import Foundation
+
+extension UIView {
+    func protectScreenshot() {
+        DispatchQueue.main.async {
+            let textField = UITextField()
+            textField.isSecureTextEntry = true
+            self.addSubview(textField)
+            textField.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+            textField.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+            textField.layer.removeFromSuperlayer()
+            self.layer.superlayer?.insertSublayer(textField.layer, at: 0)
+            textField.layer.sublayers?.last?.addSublayer(self.layer)
+        }
+    }
+}


### PR DESCRIPTION
Hi. Suzuki. First of all thank you for your code.

This PR is for protecting image from taking screenshot.
it works only on the device not simulator.

I add UITextField layer on the paginationView.
Because 'secureTextEntry' in UITextField

In detail below link is for you.
https://developer.apple.com/documentation/uikit/uitextinputtraits/1624427-securetextentry
