### PR TITLE
Fix toolbar clipping on iOS 26.0: use 48pt instead of hard-coded 44pt

### DIFF
--- a/SKPhotoBrowser/SKPhotoBrowser.swift
+++ b/SKPhotoBrowser/SKPhotoBrowser.swift
@@ -400,11 +400,16 @@ internal extension SKPhotoBrowser {
                 return 15
             }
         }()
-        return view.bounds.divided(atDistance: 44, from: .maxYEdge).slice.offsetBy(dx: 0, dy: -offset)
-    }
-    
-    func frameForToolbarHideAtOrientation() -> CGRect {
-        return view.bounds.divided(atDistance: 44, from: .maxYEdge).slice.offsetBy(dx: 0, dy: 44)
+        
+        let height: CGFloat = {
+            if #available(iOS 26.0, *) {
+                return 48
+            } else {
+                return 44
+            }
+        }()
+        
+        return view.bounds.divided(atDistance: height, from: .maxYEdge).slice.offsetBy(dx: 0, dy: -offset)
     }
     
     func frameForPaginationAtOrientation() -> CGRect {


### PR DESCRIPTION
**Summary**

On iOS 26.0, `UIToolbar` height is 48pt. Our image viewer computed a 44pt toolbar inside `frameForToolbarAtOrientation` and also used `clipsToBounds = true`, which led to top/bottom clipping of bar button items on iOS 26.0.
This MR updates `frameForToolbarAtOrientation` to return a version-aware height and removes an unused helper function.

**What’s Changed**

- Update `frameForToolbarAtOrientation` to use 48pt on iOS 26.0 and 44pt on older iOS.
- Preserve existing behavior (including `clipsToBounds = true`); only the height calculation changes.
- Remove unused `frameForToolbarHideAtOrientation` (no remaining references).

|before|after|
|---|---|
|<img width="590" height="1278" alt="截屏 2025-09-04 18 54 06" src="https://github.com/user-attachments/assets/a872d3a2-67ad-41cf-90ad-f40d8675c735" />|<img width="590" height="1278" alt="IMG_3683" src="https://github.com/user-attachments/assets/f8923e40-3600-4a1d-8925-3198eaa4cab2" />|